### PR TITLE
fix(fastio): preserve JSON mirrors for timestamped archives

### DIFF
--- a/planfile/core/fastio.py
+++ b/planfile/core/fastio.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+import warnings
+from datetime import date, datetime, time
 from pathlib import Path
 from typing import Any
 
@@ -41,8 +43,26 @@ def mirror_path(path: Path) -> Path:
     return path.with_name(path.name + _MIRROR_SUFFIX)
 
 
+def _json_safe(value: Any) -> Any:
+    """Return the YAML value in the exact JSON-mirror representation.
+
+    PyYAML resolves unquoted timestamps to ``date``/``datetime`` instances.
+    They are valid YAML but not JSON serializable, so one timestamp in a large
+    archive used to disable its mirror permanently and force every read to
+    parse the whole YAML again. Normalising at the YAML boundary also keeps a
+    cache miss and a mirror hit type-compatible.
+    """
+    if isinstance(value, dict):
+        return {_json_safe(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, (datetime, date, time)):
+        return value.isoformat()
+    return value
+
+
 def load_yaml_text(text: str) -> Any:
-    return yaml.load(text, Loader=FastLoader)
+    return _json_safe(yaml.load(text, Loader=FastLoader))
 
 
 def dump_yaml(data: Any, *, allow_unicode: bool = False) -> str:
@@ -96,10 +116,16 @@ def write_mirror(yaml_path: Path, data: Any, *, mtime_ns: int | None = None) -> 
     payload = {"version": _MIRROR_VERSION, "yaml_mtime_ns": mtime_ns, "data": data}
     try:
         _atomic_write_text(mirror_path(yaml_path), json.dumps(payload, ensure_ascii=False))
-    except Exception:
-        # The mirror is an optimization only; a failed write must never
-        # break a ticket mutation. Readers fall back to parsing the YAML.
-        pass
+    except Exception as exc:
+        # The mirror is an optimization only; a failed write must never break
+        # a ticket mutation. It must remain observable, otherwise a permanent
+        # full-YAML fallback looks like unexplained API latency.
+        warnings.warn(
+            f"planfile: JSON mirror for {yaml_path.name} not written "
+            f"({type(exc).__name__}: {exc}); reads fall back to full YAML parsing",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
 
 def read_mirror(yaml_path: Path, yaml_mtime_ns: int) -> Any | None:

--- a/tests/test_fastio.py
+++ b/tests/test_fastio.py
@@ -70,6 +70,23 @@ class TestMirrorRoundtrip:
         payload = json.loads(fastio.mirror_path(y).read_text())
         assert payload["yaml_mtime_ns"] == 12345
 
+    def test_yaml_timestamps_are_json_safe_and_mirrored(self, tmp_path):
+        y = tmp_path / "archive.yaml"
+        _write_yaml(
+            y,
+            "created_at: 2026-08-05 07:11:31.523310+00:00\n"
+            "review_on: 2026-08-12\n",
+        )
+
+        first = fastio.read_yaml_fast(y)
+
+        assert first == {
+            "created_at": "2026-08-05T07:11:31.523310+00:00",
+            "review_on": "2026-08-12",
+        }
+        assert fastio.mirror_path(y).exists()
+        assert fastio.read_yaml_fast(y) == first
+
     def test_read_does_not_cache_when_a_writer_races_mid_read(self, tmp_path, monkeypatch):
         """Reproduces the exact bug this module guards against: a reader takes no
         lock, so a concurrent writer's atomic replace can land between the reader's


### PR DESCRIPTION
## Outcome

Planfile no longer disables the JSON mirror when an archive contains YAML timestamps resolved as Python date/datetime/time objects.

## Changes

- normalize YAML timestamp objects into ISO-8601 strings at the YAML/JSON boundary
- preserve identical types between a YAML cache miss and a JSON mirror hit
- emit an observable warning if a future mirror serialization still fails
- add a regression test covering timestamped archives and the second mirror-backed read

## Verification

- `python -m pytest tests/test_fastio.py -q` — 13 passed
- `python -m pytest -q --disable-warnings --tb=short` — 339 passed, 6 skipped
- Subactor todo2code deterministic intent gate — passed (`z-ai/glm-5.2` configured; semantic stage skipped when credential unavailable)

No ticket state or production deployment is changed by this PR.