### PR TITLE
ci: replace false-red auto-loop gate with deterministic tests

### DIFF
--- a/.github/workflows/ci-auto-loop.yml
+++ b/.github/workflows/ci-auto-loop.yml
@@ -51,8 +51,19 @@ jobs:
           ollama serve &
           sleep 5
           ollama pull qwen2.5:3b
+
+      - name: Run deterministic test gate
+        run: |
+          pytest -q \
+            --junitxml=test-results.xml \
+            --cov=planfile \
+            --cov-report=json:coverage.json \
+            --cov-report=html
       
       - name: Run CI Auto-Loop
+        # The loop may create issues and requires a configured strategy. Keep
+        # it opt-in; deterministic tests above are the required PR gate.
+        if: env.AUTO_FIX == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPO: ${{ github.repository }}

--- a/.github/workflows/ci-auto-loop.yml
+++ b/.github/workflows/ci-auto-loop.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[github] pytest pytest-cov
+          pip install .[api,github] pytest pytest-cov
           pip install llx  # Install llx for AI analysis
       
       - name: Install Ollama (for local LLM)


### PR DESCRIPTION
## Outcome

PR checks now use the repository test suite as the required deterministic gate. The issue-creating auto-fix loop runs only when `AUTO_FIX=true` instead of generating five synthetic tickets on every ordinary PR.

## Why

The current `main` workflow is false-red: the auto-loop reports `0 tests`, `0% coverage`, reaches five iterations and creates five tickets even when the local suite passes.

## Verification

- workflow YAML parses successfully
- exact workflow test command: 344 tests, 0 failures, 0 errors, 6 skipped
- coverage JSON and HTML reports are generated

This PR changes CI only; it does not mutate runtime tickets or production.