### PR TITLE
fix(tickets): enforce atomic create-time deduplication

### DIFF
--- a/planfile/__init__.py
+++ b/planfile/__init__.py
@@ -106,10 +106,40 @@ class Planfile:
         return cls(start_path)  # init in CWD
 
     def create_ticket(self, name: str, **kwargs) -> Ticket:
+        return self.create_ticket_deduplicated(name, **kwargs)[0]
+
+    @staticmethod
+    def _ticket_dedupe_label(dedupe_key: str | None, labels: list[str]) -> str | None:
+        if str(dedupe_key or "").strip():
+            return f"dedupe:{str(dedupe_key).strip()}"
+        # A stable dedupe label must win over occurrence labels such as
+        # incident:<operation_id>. Producers intentionally keep both.
+        return next((label for label in labels if str(label).startswith("dedupe:") and str(label)[7:]), None)
+
+    def create_ticket_deduplicated(self, name: str, **kwargs) -> tuple[Ticket, bool]:
+        """Atomically create a ticket or return its live dedupe-key owner."""
+        dedupe_key = kwargs.pop("dedupe_key", None)
+        labels = list(kwargs.pop("labels", None) or [])
+        dedupe_label = self._ticket_dedupe_label(dedupe_key, labels)
+        if dedupe_label and dedupe_label not in labels:
+            labels.append(dedupe_label)
+        if labels:
+            kwargs["labels"] = labels
         with self.store.mutation_lock():
+            if dedupe_label:
+                live = [
+                    record for record in self.store.ticket_records(sprint="all")
+                    if dedupe_label in (record.get("labels") or [])
+                    and str(record.get("status") or "") not in {"done", "canceled"}
+                ]
+                if live:
+                    oldest = min(live, key=lambda record: str(record.get("created_at") or ""))
+                    existing = self.store.get_ticket(str(oldest.get("id") or ""))
+                    if existing:
+                        return existing, False
             ticket_id = self.store._next_id_unlocked()
             ticket = Ticket(id=ticket_id, name=name, **kwargs)
-            return self.store._create_ticket_unlocked(ticket)
+            return self.store._create_ticket_unlocked(ticket), True
 
     def get_ticket(self, ticket_id: str):
         return self.store.get_ticket(ticket_id)

--- a/planfile/api/server.py
+++ b/planfile/api/server.py
@@ -98,6 +98,7 @@ class TicketCreate(BaseModel):
     inputs: TicketInputs | None = None
     outputs: TicketOutputs | None = None
     source: TicketSource | None = None
+    dedupe_key: str | None = None
 
 
 class TicketUpdate(BaseModel):
@@ -489,10 +490,10 @@ def list_tickets(
 
 
 @app.post("/tickets", status_code=201, tags=["tickets"])
-async def create_ticket(body: TicketCreate):
+async def create_ticket(body: TicketCreate, response: Response):
     pf = get_planfile()
     _validate_process_envelope(body.labels, body.inputs)
-    ticket = pf.create_ticket(
+    ticket, created = pf.create_ticket_deduplicated(
         name=body.name,
         priority=body.priority,
         sprint=body.sprint,
@@ -503,7 +504,11 @@ async def create_ticket(body: TicketCreate):
         inputs=body.inputs,
         outputs=body.outputs,
         source=body.source or TicketSource(tool="planfile-api", version=__version__),
+        dedupe_key=body.dedupe_key,
     )
+    if not created:
+        response.status_code = 200
+        return ticket.model_dump(mode="json", exclude_none=True)
     await _broadcast_ticket_event("ticket.changed", "create", ticket)
     return ticket.model_dump(mode="json", exclude_none=True)
 

--- a/planfile/core/store.py
+++ b/planfile/core/store.py
@@ -711,6 +711,19 @@ class Store(StoreFileMixin, TicketStoreMixin):
             return self._sharded_storage().sprint_ids()
         return [path.stem for path in self._all_sprint_files()]
 
+    def ticket_records(self, sprint: str = "all"):
+        """Yield raw ticket dictionaries for bounded identity checks.
+
+        Create-time deduplication only needs status and labels. Avoid building
+        thousands of Pydantic models while holding the cross-process mutation
+        lock.
+        """
+        for sprint_id in (self._all_sprint_ids() if sprint == "all" else [sprint]):
+            root = self.load_sprint(sprint_id)
+            for record in (root.get("tickets") or {}).values():
+                if isinstance(record, dict):
+                    yield record
+
     def _sprint_storage_files(self, sprint: str) -> list[Path]:
         self._sprint_file(sprint)  # validate
         if self._uses_sharded_storage():

--- a/tests/test_ticket_create_dedupe.py
+++ b/tests/test_ticket_create_dedupe.py
@@ -1,0 +1,86 @@
+"""Atomic create-time ticket deduplication."""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from planfile import Planfile
+
+
+@pytest.fixture()
+def pf(tmp_path):
+    return Planfile(str(tmp_path))
+
+
+def _incident(pf, occurrence):
+    return pf.create_ticket_deduplicated(
+        "Incydent zależności: soa://subactor/connector/plesk",
+        labels=[
+            f"incident:{occurrence}",
+            "incident-fingerprint:shared",
+            "dedupe:ops-incident:shared",
+        ],
+    )
+
+
+def test_parallel_occurrences_with_one_dedupe_key_create_one_ticket(pf):
+    """Regression for PLF-3716/3717: occurrence ids differ, cause does not."""
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda index: _incident(pf, f"occurrence-{index}"), range(8)))
+
+    assert len({ticket.id for ticket, _ in results}) == 1
+    assert sum(created for _, created in results) == 1
+    assert len(pf.list_tickets(sprint="all")) == 1
+
+
+def test_dedupe_label_precedes_unique_incident_occurrence(pf):
+    first, created_first = _incident(pf, "one")
+    second, created_second = _incident(pf, "two")
+
+    assert created_first is True
+    assert created_second is False
+    assert second.id == first.id
+
+
+def test_terminal_ticket_releases_dedupe_key(pf):
+    first, _ = _incident(pf, "one")
+    pf.store.update_ticket(first.id, status="canceled")
+    second, created = _incident(pf, "two")
+
+    assert created is True
+    assert second.id != first.id
+
+
+def test_explicit_api_key_is_materialized_as_label(pf):
+    ticket, created = pf.create_ticket_deduplicated("Nightly", dedupe_key="nightly")
+
+    assert created is True
+    assert "dedupe:nightly" in ticket.labels
+
+
+def test_ordinary_tickets_are_not_deduplicated(pf):
+    first = pf.create_ticket("Zadanie", labels=["subactor"])
+    second = pf.create_ticket("Zadanie", labels=["subactor"])
+
+    assert second.id != first.id
+
+
+def test_http_reuse_returns_200_without_second_ticket(pf, monkeypatch):
+    pytest.importorskip("fastapi.testclient")
+    from fastapi.testclient import TestClient
+    from planfile.api import server
+
+    monkeypatch.setattr(server, "get_planfile", lambda: pf)
+    client = TestClient(server.app)
+    body = {
+        "name": "Incydent Plesk",
+        "labels": ["incident:one", "dedupe:ops-incident:shared"],
+    }
+
+    first = client.post("/tickets", json=body)
+    body["labels"][0] = "incident:two"
+    second = client.post("/tickets", json=body)
+
+    assert first.status_code == 201
+    assert second.status_code == 200
+    assert second.json()["id"] == first.json()["id"]


### PR DESCRIPTION
## Outcome

Concurrent producers now receive one live Planfile ticket for one stable `dedupe:` key, even when their occurrence-specific `incident:` labels differ.

## Root cause

Ops Observer had a process-local claim, but overlapping service instances during recreate used separate locks. Both could pass the claim and POST the same stable incident identity. PLF-3716 and PLF-3717 were created 328 ms apart with the same fingerprint and idempotency key.

## Changes

- move the final check-and-create boundary under Planfile cross-process `mutation_lock`
- give stable `dedupe:` identity precedence over occurrence-specific labels
- return HTTP 200 with the existing ticket on an idempotent hit; 201 only for a creation
- release the key after `done` or `canceled`, allowing a later real recurrence
- preserve ordinary ticket creation behavior

## Verification

- targeted regression: 19 passed
- full suite: 345 passed, 6 skipped
- Subactor todo2code deterministic gate passed; `z-ai/glm-5.2` is configured and semantic evaluation is skipped when the OpenRouter credential is unavailable

No production publication or connector mutation is part of this PR.