### PR TITLE
perf(store): keep replay DSL only in operational journal

### DIFF
--- a/planfile/core/models/ticket.py
+++ b/planfile/core/models/ticket.py
@@ -127,7 +127,8 @@ class Ticket(BaseModel):
 
     sync: dict = Field(default_factory=dict)  # {"github": {"issue": 142}}
     history: list[dict] = Field(default_factory=list)
-    # Canonical, reversible creation event. Subsequent events live in history[*].dsl.
+    # Canonical, reversible creation event. Subsequent replay events live in
+    # events/operations.jsonl; history retains compact audit metadata.
     dsl: str | None = None
 
     created_at: datetime = Field(default_factory=_utcnow)

--- a/planfile/core/store.py
+++ b/planfile/core/store.py
@@ -1304,6 +1304,17 @@ class Store(StoreFileMixin, TicketStoreMixin):
             return None
         return execution.get("state")
 
+    @staticmethod
+    def _detach_history_dsl(entry: dict) -> str:
+        """Move the replayable line to the operational journal only.
+
+        The same line is appended to ``events/operations.jsonl``. Keeping a
+        second copy in every history entry makes sprint rewrites and snapshots
+        grow with duplicated payload while history still has all audit fields
+        needed for display and triage.
+        """
+        return str(entry.pop("dsl", "") or "")
+
     @classmethod
     def _build_history_entry(
         cls,
@@ -1519,11 +1530,12 @@ class Store(StoreFileMixin, TicketStoreMixin):
                         reason=history_reason,
                         actor=history_actor,
                     )
+                    operational_dsl = self._detach_history_dsl(entry)
                     history.append(entry)
                     tickets[ticket_id]["history"] = history[-200:]
                 self._write_yaml_atomic(sprint_file, data, allow_unicode=True)
                 if changed_keys and "history" not in serialized_updates:
-                    self._append_operational_line(tickets[ticket_id]["history"][-1]["dsl"])
+                    self._append_operational_line(operational_dsl)
                 if hasattr(self, "_yaml_cache"):
                     self._yaml_cache.pop(str(sprint_file), None)
                 archive_report = (
@@ -1580,22 +1592,23 @@ class Store(StoreFileMixin, TicketStoreMixin):
             for key, value in serialized_updates.items()
             if key != "history" and previous.get(key) != value
         )
+        operational_dsl = ""
         if changed_keys and "history" not in serialized_updates:
             history = list(current.get("history") or [])
-            history.append(
-                self._build_history_entry(
-                    previous,
-                    current,
-                    changed_keys,
-                    reason=history_reason,
-                    actor=history_actor,
-                )
+            entry = self._build_history_entry(
+                previous,
+                current,
+                changed_keys,
+                reason=history_reason,
+                actor=history_actor,
             )
+            operational_dsl = self._detach_history_dsl(entry)
+            history.append(entry)
             current["history"] = history[-200:]
 
         storage.upsert_ticket(sprint, ticket_id, current)
         if changed_keys and "history" not in serialized_updates:
-            self._append_operational_line(current["history"][-1]["dsl"])
+            self._append_operational_line(operational_dsl)
         self._invalidate_sharded_cache(sprint)
         archive_report = (
             self._archive_completed_unlocked()
@@ -1690,14 +1703,14 @@ class Store(StoreFileMixin, TicketStoreMixin):
                 moved_ticket["sprint"] = to_sprint
                 moved_ticket["updated_at"] = datetime.now(UTC).isoformat()
                 history = list(moved_ticket.get("history") or [])
-                history.append(
-                    self._build_history_entry(
-                        previous_ticket,
-                        moved_ticket,
-                        ["sprint"],
-                        reason="move_ticket",
-                    )
+                entry = self._build_history_entry(
+                    previous_ticket,
+                    moved_ticket,
+                    ["sprint"],
+                    reason="move_ticket",
                 )
+                operational_dsl = self._detach_history_dsl(entry)
+                history.append(entry)
                 moved_ticket["history"] = history[-200:]
 
                 storage.upsert_ticket(to_sprint, ticket_id, moved_ticket)
@@ -1710,7 +1723,7 @@ class Store(StoreFileMixin, TicketStoreMixin):
                     raise
                 self._invalidate_sharded_cache(source_sprint)
                 self._invalidate_sharded_cache(to_sprint)
-                self._append_operational_line(moved_ticket["history"][-1]["dsl"])
+                self._append_operational_line(operational_dsl)
                 model = self._ticket_from_data(moved_ticket)
                 if model is not None:
                     self._finish_index_mutation(
@@ -1738,14 +1751,14 @@ class Store(StoreFileMixin, TicketStoreMixin):
                 moved_ticket["sprint"] = to_sprint
                 moved_ticket["updated_at"] = datetime.now(UTC).isoformat()
                 history = list(moved_ticket.get("history") or [])
-                history.append(
-                    self._build_history_entry(
-                        previous_ticket,
-                        moved_ticket,
-                        ["sprint"],
-                        reason="move_ticket",
-                    )
+                entry = self._build_history_entry(
+                    previous_ticket,
+                    moved_ticket,
+                    ["sprint"],
+                    reason="move_ticket",
                 )
+                operational_dsl = self._detach_history_dsl(entry)
+                history.append(entry)
                 moved_ticket["history"] = history[-200:]
 
                 destination_existed = destination_file.exists()
@@ -1778,7 +1791,7 @@ class Store(StoreFileMixin, TicketStoreMixin):
                 if hasattr(self, "_yaml_cache"):
                     self._yaml_cache.pop(str(source_file), None)
                     self._yaml_cache.pop(str(destination_file), None)
-                self._append_operational_line(moved_ticket["history"][-1]["dsl"])
+                self._append_operational_line(operational_dsl)
                 model = self._ticket_from_data(moved_ticket)
                 if model is not None:
                     self._finish_index_mutation(

--- a/tests/test_fastio_mirror_datetime.py
+++ b/tests/test_fastio_mirror_datetime.py
@@ -1,0 +1,77 @@
+"""The JSON mirror must survive YAML timestamps.
+
+YAML resolves an unquoted ``2026-07-23 22:55:58.543703+00:00`` into a
+``datetime``. ``write_mirror`` then raised ``TypeError`` inside a catch-all,
+so the mirror for subactor's 21.6 MB archive was never written — silently, for
+days. Every read re-parsed the whole file (~3.5 s), which is what made ticket
+writes take 5-7 s instead of ~0.4 s.
+"""
+
+import json
+
+import pytest
+
+from planfile.core.fastio import load_yaml_text, mirror_path, read_yaml_fast
+
+SPRINT_YAML = """\
+sprint:
+  id: archive-2026-07
+  tickets:
+    PLF-1231:
+      id: PLF-1231
+      name: Zakonczone zadanie
+      execution:
+        finished_at: 2026-07-23 22:55:58.543703+00:00
+      created_at: 2026-07-20
+"""
+
+
+@pytest.fixture()
+def sprint_file(tmp_path):
+    path = tmp_path / "archive-2026-07.yaml"
+    path.write_text(SPRINT_YAML, encoding="utf-8")
+    return path
+
+
+def test_timestamps_parse_to_json_safe_values():
+    data = load_yaml_text(SPRINT_YAML)
+    ticket = data["sprint"]["tickets"]["PLF-1231"]
+    assert ticket["execution"]["finished_at"] == "2026-07-23T22:55:58.543703+00:00"
+    assert ticket["created_at"] == "2026-07-20"
+    json.dumps(data)  # must not raise
+
+
+def test_mirror_is_written_for_a_file_containing_timestamps(sprint_file):
+    read_yaml_fast(sprint_file)
+    mirror = mirror_path(sprint_file)
+    assert mirror.exists(), "mirror was not written — reads will re-parse the YAML forever"
+    payload = json.loads(mirror.read_text(encoding="utf-8"))
+    assert payload["yaml_mtime_ns"] == sprint_file.stat().st_mtime_ns
+
+
+def test_second_read_is_served_from_the_mirror(sprint_file):
+    first = read_yaml_fast(sprint_file)
+
+    # Corrupt the YAML: a mirror hit must not touch it. If the mirror were
+    # missing or stale, this read would fail to parse and return None.
+    sprint_file.write_text(SPRINT_YAML, encoding="utf-8")
+    import os
+
+    stat = sprint_file.stat()
+    os.utime(sprint_file, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+    read_yaml_fast(sprint_file)
+
+    mirror = mirror_path(sprint_file)
+    payload = json.loads(mirror.read_text(encoding="utf-8"))
+    assert payload["data"] == first
+
+
+def test_mirror_write_failure_is_reported_not_swallowed(sprint_file, monkeypatch):
+    from planfile.core import fastio
+
+    def boom(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(fastio, "_atomic_write_text", boom)
+    with pytest.warns(RuntimeWarning, match="mirror"):
+        assert read_yaml_fast(sprint_file) is not None

--- a/tests/test_operational_dsl.py
+++ b/tests/test_operational_dsl.py
@@ -21,11 +21,19 @@ def test_ticket_creation_and_history_have_replayable_dsl(tmp_path):
     assert created["oql"] == "ticket.create"
     assert created["ticket_id"] == ticket.id
     updated = pf.update_ticket(ticket.id, priority="high", actor="bot:test", reason="triage")
-    history = parse(updated.history[-1]["dsl"])
-    assert history["oql"] == "ticket.update"
-    assert history["data"]["payload"]["reason"] == "triage"
     journal = pf.store.operational_events(ticket_id=ticket.id)
     assert [row["event"]["oql"] for row in journal] == ["ticket.update", "ticket.create"]
+
+    # The replayable line lives in the journal only. Storing a second copy on
+    # the ticket made history 75% of subactor's sprint file, and every write
+    # re-serialises the whole file. History keeps the audit metadata.
+    replayed = parse(journal[0]["dsl"])
+    assert replayed["oql"] == "ticket.update"
+    assert replayed["data"]["payload"]["reason"] == "triage"
+    entry = updated.history[-1]
+    assert "dsl" not in entry
+    assert entry["changes"] == ["priority"]
+    assert (entry["reason"], entry["actor"]) == ("triage", "bot:test")
 
 
 def test_ticket_dsl_redacts_nested_credentials(tmp_path):


### PR DESCRIPTION
Follow-up to #16 and #18. Removes the duplicate SODL payload from compact ticket history while preserving the canonical creation DSL and append-only operations journal. Adds timestamp-mirror and journal regressions.\n\nValidation: 349 passed, 6 skipped; git diff --check.