### PR TITLE
fix(tickets): reject immutable terminal reopen

### DIFF
--- a/planfile/api/server.py
+++ b/planfile/api/server.py
@@ -31,7 +31,7 @@ try:
         WebSocketDisconnect,
     )
     from fastapi.middleware.cors import CORSMiddleware
-    from fastapi.responses import HTMLResponse, Response
+    from fastapi.responses import HTMLResponse, JSONResponse, Response
     from pydantic import BaseModel, Field
 except ImportError as exc:
     raise ImportError("FastAPI required: pip install 'fastapi[all]' uvicorn") from exc
@@ -44,6 +44,7 @@ from planfile.core.models import (
     TicketOutputs,
     TicketSource,
 )
+from planfile.core.store import ImmutableTerminalReopenError
 from planfile.runtime_context import (
     DEFAULT_CONFIG as DEFAULT_RUNTIME_CONFIG,
     build_runtime_context,
@@ -67,6 +68,14 @@ app = FastAPI(
     version=__version__,
     lifespan=lifespan,
 )
+
+
+@app.exception_handler(ImmutableTerminalReopenError)
+async def immutable_terminal_reopen_handler(
+    _: Request,
+    __: ImmutableTerminalReopenError,
+):
+    return JSONResponse(status_code=409, content={"detail": "immutable_terminal_reopen"})
 
 _cors_origins = [
     origin.strip()

--- a/planfile/core/store.py
+++ b/planfile/core/store.py
@@ -18,6 +18,10 @@ from .store_files import StoreFileMixin
 from .store_tickets import TicketStoreMixin
 
 
+class ImmutableTerminalReopenError(RuntimeError):
+    """Raised when an ordinary mutation tries to reactivate done/canceled work."""
+
+
 class Store(StoreFileMixin, TicketStoreMixin):
     """File-based ticket store using .planfile/ directory."""
 
@@ -35,6 +39,8 @@ class Store(StoreFileMixin, TicketStoreMixin):
         "index": "none",
     }
     SPRINT_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
+    IMMUTABLE_TERMINAL_STATUSES = {"done", "canceled"}
+    TERMINAL_STATUSES = {"done", "canceled", "failed", "blocked"}
 
     def __init__(self, directory: str | Path):
         self.project_dir = Path(directory).resolve()
@@ -1381,6 +1387,34 @@ class Store(StoreFileMixin, TicketStoreMixin):
         with self.mutation_lock():
             return self._update_ticket_unlocked(ticket_id, reason=reason, actor=actor, **updates)
 
+    def _guard_immutable_terminal_reopen(
+        self,
+        previous: dict,
+        serialized_updates: dict,
+    ) -> None:
+        """Keep ordinary updates monotonic after done/canceled.
+
+        Terminal-to-terminal corrections remain possible, and append-only
+        evidence uses its dedicated API. What is forbidden is projecting an
+        active status or execution state onto work that was already completed
+        or canceled.
+        """
+
+        previous_status = str(previous.get("status") or "")
+        if previous_status not in self.IMMUTABLE_TERMINAL_STATUSES:
+            return
+
+        requested_status = str(serialized_updates.get("status") or previous_status)
+        if requested_status not in self.TERMINAL_STATUSES:
+            raise ImmutableTerminalReopenError("immutable_terminal_reopen")
+
+        execution_update = serialized_updates.get("execution")
+        if not isinstance(execution_update, dict) or "state" not in execution_update:
+            return
+        requested_state = str(execution_update.get("state") or "")
+        if requested_state != requested_status:
+            raise ImmutableTerminalReopenError("immutable_terminal_reopen")
+
     def append_ticket_evidence(
         self,
         ticket_id: str,
@@ -1502,6 +1536,7 @@ class Store(StoreFileMixin, TicketStoreMixin):
                 serialized_updates = {
                     key: self._serialize_update_value(value) for key, value in updates.items()
                 }
+                self._guard_immutable_terminal_reopen(previous, serialized_updates)
                 terminal_status = serialized_updates.get("status")
                 if terminal_status in {"done", "canceled", "blocked", "failed"}:
                     execution_update = serialized_updates.get("execution")
@@ -1571,6 +1606,7 @@ class Store(StoreFileMixin, TicketStoreMixin):
         serialized_updates = {
             key: self._serialize_update_value(value) for key, value in updates.items()
         }
+        self._guard_immutable_terminal_reopen(previous, serialized_updates)
         terminal_status = serialized_updates.get("status")
         if terminal_status in {"done", "canceled", "blocked", "failed"}:
             execution_update = serialized_updates.get("execution")

--- a/tests/test_sharded_yaml_storage.py
+++ b/tests/test_sharded_yaml_storage.py
@@ -12,6 +12,8 @@ from planfile import Planfile
 from planfile.api import server
 from planfile.cli.commands import app
 from planfile.core.fastio import mirror_path
+from planfile.core.models import TicketExecution
+from planfile.core.store import ImmutableTerminalReopenError
 
 
 def _disable_archive(pf: Planfile) -> None:
@@ -58,6 +60,30 @@ def test_migration_partitions_tickets_and_preserves_contract(tmp_path):
     }
     assert after == before
     assert pf.get_ticket(ids[-1]).name == "Ticket 205"
+
+
+def test_sharded_storage_rejects_execution_reopen_after_cancellation(tmp_path):
+    pf = Planfile(str(tmp_path))
+    _disable_archive(pf)
+    pf.store.migrate_to_sharded_yaml(shard_size=100)
+    ticket = pf.create_ticket(
+        name="Immutable sharded lifecycle",
+        execution=TicketExecution(state="running", assigned_to="bot:worker"),
+    )
+    pf.update_ticket(ticket.id, status="canceled")
+
+    with pytest.raises(ImmutableTerminalReopenError, match="immutable_terminal_reopen"):
+        pf.update_ticket(
+            ticket.id,
+            execution=TicketExecution(state="running", assigned_to="bot:late"),
+            actor="bot:late",
+            reason="stale_worker_update",
+        )
+
+    current = pf.get_ticket(ticket.id)
+    assert current is not None
+    assert current.status == "canceled"
+    assert current.execution.state == "canceled"
 
 
 def test_sharded_crud_move_and_sprint_save(tmp_path):

--- a/tests/test_ticket_api_events.py
+++ b/tests/test_ticket_api_events.py
@@ -126,6 +126,38 @@ def test_governed_ticket_requires_completion_receipt(tmp_path, monkeypatch):
     assert completed["history"][-1]["reason"] == "Expected state was observed."
 
 
+@pytest.mark.parametrize("terminal_status", ["done", "canceled"])
+def test_api_rejects_stale_worker_reopen_of_immutable_terminal(
+    tmp_path,
+    monkeypatch,
+    terminal_status,
+):
+    pf = Planfile(str(tmp_path))
+    ticket = pf.create_ticket(
+        name="Immutable API lifecycle",
+        execution=TicketExecution(state="running", assigned_to="bot:worker"),
+    )
+    pf.update_ticket(ticket.id, status=terminal_status)
+    monkeypatch.setattr(server, "get_planfile", lambda: pf)
+    client = TestClient(server.app)
+
+    response = client.patch(
+        f"/tickets/{ticket.id}",
+        json={
+            "execution": {"state": "running", "assigned_to": "bot:late"},
+            "actor": "bot:late",
+            "reason": "stale_worker_update",
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "immutable_terminal_reopen"}
+    current = pf.get_ticket(ticket.id)
+    assert current is not None
+    assert current.status == terminal_status
+    assert current.execution.state == terminal_status
+
+
 def test_governed_ticket_mutations_require_attributed_history(tmp_path, monkeypatch):
     pf = Planfile(str(tmp_path))
     uri = {"id": "read-time", "name": "Read time", "uri": "time://clock/query/now"}

--- a/tests/test_ticket_execution.py
+++ b/tests/test_ticket_execution.py
@@ -12,6 +12,7 @@ from planfile import (
     TicketOutputs,
     TicketSource,
 )
+from planfile.core.store import ImmutableTerminalReopenError
 
 
 def test_ticket_round_trip_with_execution_fields(tmp_path):
@@ -241,6 +242,54 @@ def test_terminal_status_normalizes_execution_state(tmp_path, terminal_status):
     assert terminal.execution.assigned_to is None
     assert terminal.execution.lease_expires_at is None
     assert terminal.execution.finished_at is not None
+
+
+@pytest.mark.parametrize("terminal_status", ["done", "canceled"])
+def test_immutable_terminal_ticket_rejects_ordinary_reopen(tmp_path, terminal_status):
+    pf = Planfile(str(tmp_path))
+    ticket = pf.create_ticket(
+        name="Immutable terminal lifecycle",
+        execution=TicketExecution(state="running", assigned_to="bot:test"),
+    )
+    terminal = pf.update_ticket(ticket.id, status=terminal_status)
+
+    with pytest.raises(ImmutableTerminalReopenError, match="immutable_terminal_reopen"):
+        pf.update_ticket(
+            ticket.id,
+            execution=TicketExecution(state="running", assigned_to="bot:late"),
+            actor="bot:late",
+            reason="stale_worker_update",
+        )
+    with pytest.raises(ImmutableTerminalReopenError, match="immutable_terminal_reopen"):
+        pf.ready_ticket(ticket.id, actor="bot:late", reason="stale_retry")
+
+    current = pf.get_ticket(ticket.id)
+    assert current is not None
+    assert current.status == terminal_status
+    assert current.execution is not None
+    assert current.execution.state == terminal_status
+    assert current.execution.assigned_to is None
+
+
+def test_immutable_terminal_ticket_accepts_append_only_evidence(tmp_path):
+    pf = Planfile(str(tmp_path))
+    ticket = pf.create_ticket(name="Completed work")
+    pf.update_ticket(ticket.id, status="done")
+
+    updated, recorded = pf.append_ticket_evidence(
+        ticket.id,
+        idempotency_key="late-verifier:v1",
+        collection="evidence",
+        evidence={"schema": "test.evidence/v1", "passed": True},
+        reason="late_verification",
+        actor="bot:verifier",
+    )
+
+    assert recorded is True
+    assert updated is not None
+    assert updated.status == "done"
+    assert updated.execution is not None
+    assert updated.execution.state == "done"
 
 
 def test_ready_ticket_reopens_started_ticket_and_clears_stale_execution_claim(tmp_path):


### PR DESCRIPTION
## Problem

A stale worker could PATCH only `execution.state=running` after a ticket had reached `done` or `canceled`. Planfile persisted `status=canceled / execution.state=running`, so downstream reconcilers had to repair a state the source of truth should never accept. Live reproduction: PLF-3757.

## Change

- reject active status or execution projections after immutable `done`/`canceled`
- return HTTP 409 `immutable_terminal_reopen` at the REST boundary
- preserve terminal-to-terminal audit corrections and append-only evidence
- enforce the same rule for single- and sharded-YAML storage

## Verification

- focused lifecycle/API/storage tests: 80/80
- full Planfile suite: 355 passed, 6 skipped
- `git diff --check`

No ticket data migration and no external effects.