### PR TITLE
feat(storage): daily terminal history keeps current active-only

### DIFF
--- a/.intentignore
+++ b/.intentignore
@@ -1,0 +1,4 @@
+.intent/**
+.intent-*/**
+.intent-validation/**
+.intent-validation-*/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 - GitHub publication reuses both Planfile and legacy Doctor fingerprint markers.
 
 ### Fixed
+- Kept the operational `current` sprint active-only by moving terminal tickets
+  into `history-YYYY-MM-DD` files immediately by default. Added startup/daily
+  maintenance, a lightweight history locator for bounded lookups, and stale
+  snapshot protection so archived tickets cannot be resurrected by bulk sync.
 - Fixed `planfile serve` install hint: Rich no longer swallows `[api]` as
   console markup, so the error now prints the correct
   `pip install 'planfile[api]'` instead of an extras-less command.

--- a/README.md
+++ b/README.md
@@ -359,12 +359,20 @@ planfile ticket bulk-update \
 
 #### Bounded ticket storage
 
-Planfile automatically keeps `.planfile/sprints/current.yaml` bounded. When the
-file exceeds 100 tickets or 1 MB, the oldest `done`, `canceled`, `failed`, and `blocked` tickets are
-moved into monthly `.planfile/sprints/archive-YYYY-MM.yaml` files. The 20 most
-recent terminal tickets stay in the current sprint, and active tickets are
-never archived. Ticket IDs and history are preserved; use `sprint=all` when a
-listing must include archives.
+Planfile automatically separates operational work from history. Terminal
+`done`, `canceled`, `failed`, and `blocked` tickets move into daily
+`.planfile/sprints/history-YYYY-MM-DD.yaml` files as soon as they become
+terminal. The sweep also runs when the API starts and once per UTC day to catch
+external file edits. If `current` exceeds 100
+tickets or 1 MB, Planfile may also rotate older terminal work while keeping the
+20 most recent terminal tickets. Active tickets are never archived. Ticket IDs
+and history are preserved; use `sprint=all` only when a listing intentionally
+needs history. Existing monthly `archive-YYYY-MM.yaml` files remain readable.
+Planfile keeps a small locator in
+`.planfile/index/history-locations.yaml`, so normal ticket lookups and stale
+snapshot protection do not need to parse every history file.
+See [Daily terminal history](docs/guides/DAILY_TERMINAL_HISTORY.md) for the
+ordering and compatibility contract.
 
 The defaults apply to existing projects without a configuration change. They
 can be adjusted or disabled through the validated configuration interface (or
@@ -382,8 +390,13 @@ archive:
   max_current_tickets: 100
   max_current_bytes: 1000000
   retain_terminal_tickets: 20
+  retain_terminal_days: 0
   terminal_statuses: [done, canceled, failed, blocked]
 ```
+
+`retain_terminal_days: 0` keeps `current` active-only. Set it to `1` to keep
+terminal tickets from the current UTC date, or a larger number for a longer
+operational review window.
 
 For large or frequently mutated queues, Planfile also provides an opt-in
 sharded YAML backend. It keeps the public ticket/API contract unchanged while

--- a/docs/guides/DAILY_TERMINAL_HISTORY.md
+++ b/docs/guides/DAILY_TERMINAL_HISTORY.md
@@ -1,0 +1,44 @@
+# Daily terminal history
+
+Status: implemented
+
+## Intent
+
+Keep the operational Planfile dataset small by moving work that no longer needs
+execution out of `current`, without losing auditability, dependency semantics,
+or compatibility with existing archives.
+
+## Contract
+
+When a ticket enters `done`, `canceled`, `failed`, or `blocked`, Planfile moves
+it to `.planfile/sprints/history-YYYY-MM-DD.yaml`. The UTC date comes from
+`execution.finished_at`, then `updated_at`, then `created_at`. By default,
+`store.archive.retain_terminal_days: 0` rotates terminal work immediately. A
+positive value retains that many UTC calendar dates, including today. Existing
+count and byte thresholds remain an additional safety boundary.
+
+Rotation holds the global mutation lock. It writes all history destinations,
+then `.planfile/index/history-locations.yaml`, and only then removes records from
+`current`. An interrupted write may temporarily duplicate a ticket, but a retry
+must repair the duplicate and must never lose the ticket. The locator lets point
+lookups, dependency resolution, and stale-snapshot protection read the exact
+daily file instead of parsing all history.
+
+The API runs an idempotent sweep on startup and once per UTC date, in addition
+to mutation-time rotation. Normal dashboard and watcher reads use
+`sprint=current`; callers use `sprint=all` only for an intentional full-history
+query. Existing `archive-YYYY-MM.yaml` files remain readable.
+
+## Acceptance requirements
+
+- Planfile MUST keep non-terminal tickets in their active sprint and MUST NOT
+  move them during terminal-history maintenance.
+- Planfile MUST group terminal tickets by completion date for both single-YAML
+  and sharded-YAML backends.
+- Rotation MUST preserve ticket IDs, ticket history, evidence, and dependency
+  semantics.
+- A stale bulk snapshot MUST NOT resurrect a ticket already owned by history.
+- An active-ticket lookup MUST read `current` before reading any history file.
+- Existing monthly archive files MUST remain readable.
+- The startup and daily maintenance task MUST be cancellable during API
+  shutdown and MUST report failures without terminating the server.

--- a/docs/guides/TICKET_STORAGE_SCALING_PLAN.md
+++ b/docs/guides/TICKET_STORAGE_SCALING_PLAN.md
@@ -111,6 +111,13 @@ Migration is refused when target shard directories are non-empty. The current
 implementation retains recovery backups but deliberately rejects reverse
 migration until a verified reconstruction operation is implemented.
 
+## Daily terminal history
+
+Terminal-ticket rotation is implemented as an active-only operational view with
+daily history files and a bounded lookup locator. See
+[Daily terminal history](DAILY_TERMINAL_HISTORY.md) for the normative contract,
+crash-ordering rules, configuration, and acceptance invariants.
+
 ## SQLite options
 
 Two SQLite modes should be evaluated after sharded YAML:

--- a/planfile/__init__.py
+++ b/planfile/__init__.py
@@ -253,12 +253,30 @@ class Planfile:
         is_bug = 0 if ticket.labels and "bug" in ticket.labels else 1
         return (priority_order.get(str(ticket.priority), 99), is_bug, str(ticket.created_at), ticket.id)
 
+    def _ticket_snapshot_with_dependencies(self, tickets: list["Ticket"]) -> dict[str, "Ticket"]:
+        """Extend one current snapshot with directly located archived dependencies."""
+        ticket_by_id = {ticket.id: ticket for ticket in tickets}
+        if not hasattr(self, "store"):
+            return ticket_by_id
+        locations = self.store._history_locations()
+        dependency_ids = {
+            dependency
+            for ticket in tickets
+            for dependency in (ticket.blocked_by or [])
+            if dependency not in ticket_by_id and dependency in locations
+        }
+        for dependency in dependency_ids:
+            archived = self.get_ticket(dependency)
+            if archived is not None:
+                ticket_by_id[dependency] = archived
+        return ticket_by_id
+
     def runnable_report(self, sprint: str = "current", queue: str | None = None) -> dict:
         """Explain runnability for every open ticket — for ``planfile ticket next --debug`` and
         dashboards: ``{selected, servable: [ids], skipped: [{id, reason}]}`` (servable in serve order)."""
         servable, skipped = [], []
         tickets = self.list_tickets(sprint=sprint)
-        ticket_by_id = {ticket.id: ticket for ticket in tickets}
+        ticket_by_id = self._ticket_snapshot_with_dependencies(tickets)
         for ticket in tickets:
             status = ticket.status.value if hasattr(ticket.status, "value") else str(ticket.status)
             if status != "open":
@@ -278,7 +296,7 @@ class Planfile:
         bug-first within priority. Skips frozen-frontier / human-waiting / resource-waiting / off-goal
         / dependency-blocked tickets so an autonomous queue never loops on un-doable work."""
         tickets = self.list_tickets(sprint=sprint)
-        ticket_by_id = {ticket.id: ticket for ticket in tickets}
+        ticket_by_id = self._ticket_snapshot_with_dependencies(tickets)
         runnable = (
             ticket
             for ticket in tickets

--- a/planfile/api/server.py
+++ b/planfile/api/server.py
@@ -47,6 +47,8 @@ from planfile.core.models import (
 from planfile.core.store import ImmutableTerminalReopenError
 from planfile.runtime_context import (
     DEFAULT_CONFIG as DEFAULT_RUNTIME_CONFIG,
+)
+from planfile.runtime_context import (
     build_runtime_context,
     load_runtime_context_config,
 )
@@ -55,11 +57,13 @@ from planfile.server_common import get_planfile
 
 @asynccontextmanager
 async def lifespan(_: FastAPI):
+    await _start_archive_maintenance()
     await _start_planfile_watcher()
     try:
         yield
     finally:
         await _stop_planfile_watcher()
+        await _stop_archive_maintenance()
 
 
 app = FastAPI(
@@ -1021,6 +1025,7 @@ _manager = ConnectionManager()
 _EVENT_HISTORY_LIMIT = 200
 _event_history: deque[dict[str, Any]] = deque(maxlen=_EVENT_HISTORY_LIMIT)
 _watch_task: asyncio.Task | None = None
+_archive_maintenance_task: asyncio.Task | None = None
 _watch_snapshot: dict[str, str] = {}
 _watch_source_signature: tuple = ()
 
@@ -1137,6 +1142,71 @@ async def _watch_planfile_changes(interval_seconds: float = 3.0) -> None:
                 await _broadcast_ticket_event("ticket.external.changed", "external-update", by_id[ticket_id])
         _watch_snapshot = current
         _watch_source_signature = source_signature
+
+
+async def _archive_history_daily(interval_seconds: float = 300.0) -> None:
+    """Run the idempotent history sweep once on startup and per UTC date."""
+    last_run_date = None
+    while True:
+        today = datetime.now(UTC).date()
+        if today != last_run_date:
+            try:
+                report = await asyncio.to_thread(
+                    get_planfile().store.archive_completed
+                )
+            except Exception as exc:  # pragma: no cover - defensive runtime telemetry
+                _remember_event(
+                    {
+                        "type": "management.event",
+                        "action": "daily-history-error",
+                        "ticket_id": "-",
+                        "created_at": datetime.now(UTC).isoformat(),
+                        "source": "planfile",
+                        "tool": "planfile.api",
+                        "level": "error",
+                        "status": "failed",
+                        "message": "daily terminal-ticket history sweep failed",
+                        "details": {"error": str(exc)},
+                    }
+                )
+            else:
+                last_run_date = today
+                if report.get("archived"):
+                    _remember_event(
+                        {
+                            "type": "management.event",
+                            "action": "daily-history",
+                            "ticket_id": "-",
+                            "created_at": datetime.now(UTC).isoformat(),
+                            "source": "planfile",
+                            "tool": "planfile.api",
+                            "level": "info",
+                            "status": "done",
+                            "message": "terminal tickets moved to daily history",
+                            "details": report,
+                        }
+                    )
+        await asyncio.sleep(interval_seconds)
+
+
+async def _start_archive_maintenance() -> None:
+    global _archive_maintenance_task
+    if os.environ.get("PLANFILE_DISABLE_ARCHIVE_MAINTENANCE") == "1":
+        return
+    if _archive_maintenance_task is None or _archive_maintenance_task.done():
+        _archive_maintenance_task = asyncio.create_task(_archive_history_daily())
+
+
+async def _stop_archive_maintenance() -> None:
+    global _archive_maintenance_task
+    if _archive_maintenance_task is None:
+        return
+    _archive_maintenance_task.cancel()
+    try:
+        await _archive_maintenance_task
+    except asyncio.CancelledError:
+        pass
+    _archive_maintenance_task = None
 
 
 async def _start_planfile_watcher() -> None:

--- a/planfile/core/configuration.py
+++ b/planfile/core/configuration.py
@@ -8,17 +8,19 @@ import json
 import os
 import re
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
+from planfile.core.operational_dsl import canonical_json, redact
 from planfile.core.operational_dsl import line as operational_line
-from planfile.core.operational_dsl import canonical_json
-from planfile.core.operational_dsl import redact
 from planfile.runtime_context import (
     DEFAULT_CONFIG as DEFAULT_RUNTIME_CONFIG,
+)
+from planfile.runtime_context import (
     load_runtime_context_config,
     save_runtime_context_config,
 )
@@ -201,6 +203,11 @@ STORE_SETTINGS: dict[str, Setting] = {
     ),
     "store.archive.retain_terminal_tickets": Setting(
         _nonnegative_integer, ".planfile/config.yaml", "Terminal tickets retained in current sprint"
+    ),
+    "store.archive.retain_terminal_days": Setting(
+        _nonnegative_integer,
+        ".planfile/config.yaml",
+        "UTC calendar dates retained before terminal tickets move to daily history",
     ),
     "store.archive.terminal_statuses": Setting(
         _terminal_statuses, ".planfile/config.yaml", "Statuses eligible for archiving"

--- a/planfile/core/store.py
+++ b/planfile/core/store.py
@@ -6,7 +6,7 @@ import re
 import shutil
 import tempfile
 from contextlib import contextmanager
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from pathlib import Path
 
@@ -30,6 +30,7 @@ class Store(StoreFileMixin, TicketStoreMixin):
         "max_current_tickets": 100,
         "max_current_bytes": 1_000_000,
         "retain_terminal_tickets": 20,
+        "retain_terminal_days": 0,
         "terminal_statuses": ["done", "canceled", "failed", "blocked"],
     }
     DEFAULT_STORAGE_CONFIG = {
@@ -51,6 +52,7 @@ class Store(StoreFileMixin, TicketStoreMixin):
         self._operations_path = self.base_dir / "events" / "operations.jsonl"
         self._evidence_dir = self.base_dir / "evidence"
         self._ticket_index_path = self.base_dir / "index" / "tickets.sqlite3"
+        self._history_locations_path = self.base_dir / "index" / "history-locations.yaml"
 
     def _storage_config(self) -> dict:
         configured = self._read_config().get("storage") or {}
@@ -328,7 +330,8 @@ class Store(StoreFileMixin, TicketStoreMixin):
             with self.mutation_lock():
                 storage = self._sharded_storage()
                 current = storage.load_sprint(sprint)
-                merged = self._merge_sprint_snapshots(current, data)
+                incoming = self._exclude_tickets_owned_by_history(sprint, data)
+                merged = self._merge_sprint_snapshots(current, incoming)
                 storage.write_sprint(sprint, merged)
                 self._invalidate_sharded_cache(sprint)
             if sprint == "current":
@@ -340,7 +343,8 @@ class Store(StoreFileMixin, TicketStoreMixin):
             from planfile.core.fastio import read_yaml_fast
 
             current = read_yaml_fast(path) or {}
-            merged = self._merge_sprint_snapshots(current, data)
+            incoming = self._exclude_tickets_owned_by_history(sprint, data)
+            merged = self._merge_sprint_snapshots(current, incoming)
             self._write_yaml_atomic(path, merged, allow_unicode=True)
         if hasattr(self, "_yaml_cache"):
             self._yaml_cache.pop(str(path), None)
@@ -463,6 +467,60 @@ class Store(StoreFileMixin, TicketStoreMixin):
     def _write_config(self, config: dict) -> None:
         self._write_yaml_atomic(self._config_path, config)
 
+    def _history_locations(self) -> dict[str, str]:
+        """Return the small durable ticket-to-history locator projection."""
+        if not self._history_locations_path.exists():
+            return {}
+        data = self._read_yaml_cached(self._history_locations_path) or {}
+        locations = data.get("tickets", {}) if isinstance(data, dict) else {}
+        if not isinstance(locations, dict):
+            return {}
+        return {
+            str(ticket_id): str(sprint)
+            for ticket_id, sprint in locations.items()
+            if self.SPRINT_ID_PATTERN.fullmatch(str(sprint))
+        }
+
+    def _record_history_locations_unlocked(self, locations: dict[str, str]) -> None:
+        if not locations:
+            return
+        current = self._history_locations()
+        current.update(locations)
+        self._write_yaml_atomic(
+            self._history_locations_path,
+            {
+                "schema": "planfile.history-locations/v1",
+                "tickets": current,
+            },
+            allow_unicode=True,
+        )
+
+    def _exclude_tickets_owned_by_history(self, sprint: str, data: dict) -> dict:
+        """Prevent a stale bulk snapshot from resurrecting archived tickets."""
+        if sprint.startswith(("history-", "archive-")):
+            return data
+        locations = self._history_locations()
+        if not locations or not isinstance(data, dict):
+            return data
+        root = data.get("sprint", data)
+        if not isinstance(root, dict) or not isinstance(root.get("tickets"), dict):
+            return data
+        filtered = {
+            ticket_id: ticket
+            for ticket_id, ticket in root["tickets"].items()
+            if locations.get(str(ticket_id)) in {None, sprint}
+        }
+        if len(filtered) == len(root["tickets"]):
+            return data
+        result = dict(data)
+        result_root = dict(root)
+        result_root["tickets"] = filtered
+        if "sprint" in data:
+            result["sprint"] = result_root
+        else:
+            result = result_root
+        return result
+
     def _next_id_unlocked(self) -> str:
         return self._reserve_ids_unlocked(1)[0]
 
@@ -485,7 +543,12 @@ class Store(StoreFileMixin, TicketStoreMixin):
             configured = {}
         result = dict(self.DEFAULT_ARCHIVE_CONFIG)
         result.update(configured)
-        for key in ("max_current_tickets", "max_current_bytes", "retain_terminal_tickets"):
+        for key in (
+            "max_current_tickets",
+            "max_current_bytes",
+            "retain_terminal_tickets",
+            "retain_terminal_days",
+        ):
             try:
                 result[key] = max(0, int(result[key]))
             except (TypeError, ValueError):
@@ -496,6 +559,41 @@ class Store(StoreFileMixin, TicketStoreMixin):
         result["terminal_statuses"] = {str(status).lower() for status in statuses}
         result["enabled"] = bool(result.get("enabled", True))
         return result
+
+    @staticmethod
+    def _terminal_archive_candidates(
+        terminal: list[tuple[datetime, str, dict]],
+        config: dict,
+        *,
+        capacity_triggered: bool,
+        now: datetime | None = None,
+    ) -> list[tuple[datetime, str, dict]]:
+        """Select stale terminal tickets plus any required by the size limits.
+
+        ``retain_terminal_days=0`` moves terminal tickets immediately. Larger
+        values retain that many UTC calendar dates including today. Count
+        retention only applies to capacity-driven rotation and never keeps stale
+        work in the operational sprint indefinitely.
+        """
+        current = now or datetime.now(UTC)
+        if current.tzinfo is None:
+            current = current.replace(tzinfo=UTC)
+        retention_days = config["retain_terminal_days"]
+        if retention_days == 0:
+            selected_ids = {ticket_id for _, ticket_id, _ in terminal}
+        else:
+            cutoff_date = current.astimezone(UTC).date() - timedelta(
+                days=retention_days - 1
+            )
+            selected_ids = {
+                ticket_id
+                for timestamp, ticket_id, _ in terminal
+                if timestamp.date() < cutoff_date
+            }
+        if capacity_triggered:
+            move_count = max(0, len(terminal) - config["retain_terminal_tickets"])
+            selected_ids.update(ticket_id for _, ticket_id, _ in terminal[:move_count])
+        return [item for item in terminal if item[1] in selected_ids]
 
     @staticmethod
     def _ticket_archive_timestamp(ticket: dict) -> datetime:
@@ -521,12 +619,14 @@ class Store(StoreFileMixin, TicketStoreMixin):
         return datetime.now(UTC)
 
     def archive_completed(self, *, force: bool = False) -> dict:
-        """Archive old terminal tickets when ``current.yaml`` exceeds its limits.
+        """Move stale terminal tickets into daily history files.
 
-        Archive files are partitioned by month. The operation is serialized with all
-        other store mutations and is idempotent after an interrupted multi-file write.
-        ``force`` applies the configured retention immediately without weakening the
-        terminal-status guard.
+        Terminal tickets from prior UTC dates are rotated even below the current
+        sprint limits. Size and count limits can rotate additional terminal work
+        while retaining the configured number of recent entries. The operation is
+        serialized with all other store mutations and is idempotent after an
+        interrupted multi-file write. ``force`` applies count retention immediately
+        without weakening the terminal-status guard.
         """
         with self.mutation_lock():
             return self._archive_completed_unlocked(force=force)
@@ -563,10 +663,6 @@ class Store(StoreFileMixin, TicketStoreMixin):
         except OSError:
             current_size = 0
         over_size = config["max_current_bytes"] > 0 and current_size > config["max_current_bytes"]
-        if not (force or over_count or over_size):
-            return report
-        report["triggered"] = True
-
         terminal = [
             (self._ticket_archive_timestamp(ticket), ticket_id, ticket)
             for ticket_id, ticket in tickets.items()
@@ -574,14 +670,19 @@ class Store(StoreFileMixin, TicketStoreMixin):
             and str(ticket.get("status", "")).lower() in config["terminal_statuses"]
         ]
         terminal.sort(key=lambda item: (item[0], item[1]))
-        move_count = max(0, len(terminal) - config["retain_terminal_tickets"])
-        if move_count == 0:
+        selected = self._terminal_archive_candidates(
+            terminal,
+            config,
+            capacity_triggered=force or over_count or over_size,
+        )
+        if not selected:
             return report
+        report["triggered"] = True
 
         archive_data: dict[Path, dict] = {}
         moved_ids: list[str] = []
-        for timestamp, ticket_id, ticket in terminal[:move_count]:
-            archive_name = f"archive-{timestamp:%Y-%m}"
+        for timestamp, ticket_id, ticket in selected:
+            archive_name = f"history-{timestamp:%Y-%m-%d}"
             archive_file = self._sprint_file(archive_name)
             archive = archive_data.get(archive_file)
             if archive is None:
@@ -589,7 +690,7 @@ class Store(StoreFileMixin, TicketStoreMixin):
                 archive = archive or {
                     "sprint": {
                         "id": archive_name,
-                        "name": f"Archive {timestamp:%Y-%m}",
+                        "name": f"History {timestamp:%Y-%m-%d}",
                         "status": "archived",
                         "tickets": {},
                     }
@@ -610,6 +711,12 @@ class Store(StoreFileMixin, TicketStoreMixin):
             self._write_yaml_atomic(archive_file, archive, allow_unicode=True)
             if hasattr(self, "_yaml_cache"):
                 self._yaml_cache.pop(str(archive_file), None)
+        self._record_history_locations_unlocked(
+            {
+                ticket_id: f"history-{timestamp:%Y-%m-%d}"
+                for timestamp, ticket_id, _ in selected
+            }
+        )
         for ticket_id in moved_ids:
             tickets.pop(ticket_id, None)
         self._write_yaml_atomic(current_file, data, allow_unicode=True)
@@ -647,10 +754,6 @@ class Store(StoreFileMixin, TicketStoreMixin):
             config["max_current_bytes"] > 0
             and storage.sprint_size("current") > config["max_current_bytes"]
         )
-        if not (force or over_count or over_size):
-            return report
-        report["triggered"] = True
-
         terminal = [
             (self._ticket_archive_timestamp(ticket), ticket_id, ticket)
             for ticket_id, ticket in tickets.items()
@@ -658,14 +761,19 @@ class Store(StoreFileMixin, TicketStoreMixin):
             and str(ticket.get("status", "")).lower() in config["terminal_statuses"]
         ]
         terminal.sort(key=lambda item: (item[0], item[1]))
-        move_count = max(0, len(terminal) - config["retain_terminal_tickets"])
-        if move_count == 0:
+        selected = self._terminal_archive_candidates(
+            terminal,
+            config,
+            capacity_triggered=force or over_count or over_size,
+        )
+        if not selected:
             return report
+        report["triggered"] = True
 
         archives: dict[str, dict] = {}
         moved_ids = []
-        for timestamp, ticket_id, ticket in terminal[:move_count]:
-            archive_name = f"archive-{timestamp:%Y-%m}"
+        for timestamp, ticket_id, ticket in selected:
+            archive_name = f"history-{timestamp:%Y-%m-%d}"
             archive = archives.get(archive_name)
             if archive is None:
                 if archive_name in storage.sprint_ids():
@@ -674,7 +782,7 @@ class Store(StoreFileMixin, TicketStoreMixin):
                     archive = {
                         "sprint": {
                             "id": archive_name,
-                            "name": f"Archive {timestamp:%Y-%m}",
+                            "name": f"History {timestamp:%Y-%m-%d}",
                             "status": "archived",
                             "tickets": {},
                         }
@@ -689,6 +797,12 @@ class Store(StoreFileMixin, TicketStoreMixin):
         for archive_name, archive in archives.items():
             storage.write_sprint(archive_name, archive)
             self._invalidate_sharded_cache(archive_name)
+        self._record_history_locations_unlocked(
+            {
+                ticket_id: f"history-{timestamp:%Y-%m-%d}"
+                for timestamp, ticket_id, _ in selected
+            }
+        )
         for ticket_id in moved_ids:
             tickets.pop(ticket_id, None)
         storage.write_sprint("current", data)
@@ -709,12 +823,29 @@ class Store(StoreFileMixin, TicketStoreMixin):
             raise ValueError(f"invalid_sprint_id:{sprint}")
         return self._sprints_dir / f"{sprint}.yaml"
 
+    @staticmethod
+    def _sprint_sort_key(sprint: str) -> tuple[int, str]:
+        """Keep operational data ahead of potentially large history scans."""
+        if sprint == "current":
+            return 0, sprint
+        if sprint == "backlog":
+            return 1, sprint
+        if sprint.startswith(("history-", "archive-")):
+            return 3, sprint
+        return 2, sprint
+
     def _all_sprint_files(self) -> list[Path]:
-        return sorted(self._sprints_dir.glob("*.yaml"))
+        return sorted(
+            self._sprints_dir.glob("*.yaml"),
+            key=lambda path: self._sprint_sort_key(path.stem),
+        )
 
     def _all_sprint_ids(self) -> list[str]:
         if self._uses_sharded_storage():
-            return self._sharded_storage().sprint_ids()
+            return sorted(
+                self._sharded_storage().sprint_ids(),
+                key=self._sprint_sort_key,
+            )
         return [path.stem for path in self._all_sprint_files()]
 
     def ticket_records(self, sprint: str = "all"):
@@ -1080,7 +1211,7 @@ class Store(StoreFileMixin, TicketStoreMixin):
                 "custom_shards": custom_shards,
                 "sprints": len(snapshots),
                 "tickets": sum(
-                    len((snapshot.get("sprint", snapshot).get("tickets") or {}))
+                    len(snapshot.get("sprint", snapshot).get("tickets") or {})
                     for snapshot in snapshots.values()
                 ),
                 "backup_dir": str(backup_dir),
@@ -1279,9 +1410,37 @@ class Store(StoreFileMixin, TicketStoreMixin):
         if self.ticket_index_enabled():
             return self.indexed_ticket(ticket_id)
         if self._uses_sharded_storage():
-            located = self._sharded_storage().locate_ticket(ticket_id)
+            storage = self._sharded_storage()
+            active = storage.get_ticket("current", ticket_id)
+            if active is not None:
+                return self._ticket_from_data(active)
+            history_sprint = self._history_locations().get(ticket_id)
+            if history_sprint:
+                archived = storage.get_ticket(history_sprint, ticket_id)
+                if archived is not None:
+                    return self._ticket_from_data(archived)
+            located = storage.locate_ticket(ticket_id)
             return self._ticket_from_data(located[1]) if located is not None else None
+        checked_files = set()
+        current_file = self._sprint_file("current")
+        current_data = self._read_yaml_cached(current_file) or {}
+        checked_files.add(current_file)
+        current_root = current_data.get("sprint", current_data)
+        active = (current_root.get("tickets") or {}).get(ticket_id)
+        if active is not None:
+            return self._ticket_from_data(active)
+        history_sprint = self._history_locations().get(ticket_id)
+        if history_sprint:
+            history_file = self._sprint_file(history_sprint)
+            history_data = self._read_yaml_cached(history_file) or {}
+            checked_files.add(history_file)
+            history_root = history_data.get("sprint", history_data)
+            archived = (history_root.get("tickets") or {}).get(ticket_id)
+            if archived is not None:
+                return self._ticket_from_data(archived)
         for sprint_file in self._all_sprint_files():
+            if sprint_file in checked_files:
+                continue
             data = self._read_yaml_cached(sprint_file)
             if not data:
                 continue
@@ -1573,12 +1732,13 @@ class Store(StoreFileMixin, TicketStoreMixin):
                     self._append_operational_line(operational_dsl)
                 if hasattr(self, "_yaml_cache"):
                     self._yaml_cache.pop(str(sprint_file), None)
+                updated_ticket = dict(tickets[ticket_id])
                 archive_report = (
                     self._archive_completed_unlocked()
                     if sprint_file == self._sprint_file("current")
                     else {"archived": 0}
                 )
-                model = self._ticket_from_data(tickets[ticket_id])
+                model = self._ticket_from_data(updated_ticket)
                 if model is not None and not archive_report.get("archived"):
                     self._finish_index_mutation(
                         index_was_current,

--- a/tests/test_archive_maintenance.py
+++ b/tests/test_archive_maintenance.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from planfile.api import server
+
+
+def test_daily_maintenance_runs_history_sweep_immediately(monkeypatch):
+    calls = []
+
+    class FakeStore:
+        def archive_completed(self):
+            calls.append("archive")
+            return {
+                "triggered": True,
+                "archived": 2,
+                "remaining": 1,
+                "archive_files": ["history-2026-08-04"],
+            }
+
+    async def stop_after_first_iteration(_):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(
+        server,
+        "get_planfile",
+        lambda: SimpleNamespace(store=FakeStore()),
+    )
+    monkeypatch.setattr(server.asyncio, "sleep", stop_after_first_iteration)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(server._archive_history_daily(interval_seconds=0))
+
+    assert calls == ["archive"]
+    assert any(event.get("action") == "daily-history" for event in server._event_history)

--- a/tests/test_sharded_yaml_storage.py
+++ b/tests/test_sharded_yaml_storage.py
@@ -152,6 +152,7 @@ def test_sharded_archiving_keeps_active_tickets(tmp_path):
         max_current_tickets=3,
         max_current_bytes=0,
         retain_terminal_tickets=1,
+        retain_terminal_days=1,
     )
     pf.store._write_config(config)
     pf.store.migrate_to_sharded_yaml(shard_size=2)
@@ -163,7 +164,7 @@ def test_sharded_archiving_keeps_active_tickets(tmp_path):
     active_a = pf.create_ticket(name="active a")
     active_b = pf.create_ticket(name="active b")
 
-    assert pf.get_ticket(first.id).sprint.startswith("archive-")
+    assert pf.get_ticket(first.id).sprint.startswith("history-")
     assert pf.get_ticket(second.id).sprint == "current"
     assert {ticket.id for ticket in pf.list_tickets(sprint="current")} == {
         second.id,

--- a/tests/test_ticket_archive_force.py
+++ b/tests/test_ticket_archive_force.py
@@ -17,6 +17,7 @@ def test_forced_archive_applies_retention_but_never_moves_active_ticket(tmp_path
         "max_current_tickets": 100,
         "max_current_bytes": 10_000_000,
         "retain_terminal_tickets": 1,
+        "retain_terminal_days": 10_000,
         "terminal_statuses": ["done", "blocked"],
     }
     store._config_path.write_text(yaml.safe_dump(config, sort_keys=False))
@@ -30,6 +31,6 @@ def test_forced_archive_applies_retention_but_never_moves_active_ticket(tmp_path
 
     assert report["triggered"] is True
     assert report["archived"] == 1
-    assert store.get_ticket("PLF-001").sprint == f"archive-{old:%Y-%m}"
+    assert store.get_ticket("PLF-001").sprint == f"history-{old:%Y-%m-%d}"
     assert store.get_ticket("PLF-002").sprint == "current"
     assert store.get_ticket("PLF-003").sprint == "current"

--- a/tests/test_ticket_archiving.py
+++ b/tests/test_ticket_archiving.py
@@ -16,6 +16,9 @@ def _store(tmp_path, **archive_config) -> Store:
         "max_current_tickets": 5,
         "max_current_bytes": 0,
         "retain_terminal_tickets": 2,
+        # Capacity-focused tests use one synthetic historical date. Daily-age
+        # rotation is covered separately below.
+        "retain_terminal_days": 10_000,
         **archive_config,
     })
     store._write_config(config)
@@ -23,7 +26,7 @@ def _store(tmp_path, **archive_config) -> Store:
 
 
 def _ticket(ticket_id: str, status: str, age_days: int = 0) -> Ticket:
-    timestamp = datetime(2026, 7, 20, tzinfo=UTC) - timedelta(days=age_days)
+    timestamp = datetime(2026, 7, 20, 12, tzinfo=UTC) - timedelta(minutes=age_days)
     return Ticket(
         id=ticket_id,
         name=ticket_id,
@@ -48,7 +51,7 @@ def test_archives_oldest_terminal_tickets_after_current_limit(tmp_path):
         store.create_ticket(_ticket(f"PLF-{number:03d}", "done", age_days=10 - number))
 
     current = store.list_tickets(sprint="current")
-    archived = store.list_tickets(sprint="archive-2026-07")
+    archived = store.list_tickets(sprint="history-2026-07-20")
 
     assert [ticket.id for ticket in current] == ["PLF-005", "PLF-006"]
     assert [ticket.id for ticket in archived] == [
@@ -57,7 +60,7 @@ def test_archives_oldest_terminal_tickets_after_current_limit(tmp_path):
         "PLF-003",
         "PLF-004",
     ]
-    assert all(ticket.sprint == "archive-2026-07" for ticket in archived)
+    assert all(ticket.sprint == "history-2026-07-20" for ticket in archived)
     assert len(store.list_tickets(sprint="all")) == 6
 
 
@@ -73,7 +76,7 @@ def test_active_tickets_are_never_archived(tmp_path):
         "PLF-003",
         "PLF-004",
     }
-    assert [ticket.id for ticket in store.list_tickets(sprint="archive-2026-07")] == [
+    assert [ticket.id for ticket in store.list_tickets(sprint="history-2026-07-20")] == [
         "PLF-001"
     ]
 
@@ -84,7 +87,7 @@ def test_archiving_can_be_disabled_per_project(tmp_path):
         store.create_ticket(_ticket(f"PLF-{number:03d}", "done", age_days=number))
 
     assert len(store.list_tickets(sprint="current")) == 3
-    assert not list(store._sprints_dir.glob("archive-*.yaml"))
+    assert not list(store._sprints_dir.glob("history-*.yaml"))
 
 
 def test_list_tickets_reuses_models_until_snapshot_changes(tmp_path, monkeypatch):
@@ -130,7 +133,7 @@ def test_update_triggers_archiving_and_keeps_fresh_completion_current(tmp_path):
 
     assert updated is not None and str(updated.status.value) == "done"
     assert store.get_ticket("PLF-004").sprint == "current"
-    assert store.get_ticket("PLF-001").sprint == "archive-2026-07"
+    assert store.get_ticket("PLF-001").sprint == "history-2026-07-20"
 
 
 def test_size_limit_can_trigger_archiving_below_count_limit(tmp_path):
@@ -144,4 +147,109 @@ def test_size_limit_can_trigger_archiving_below_count_limit(tmp_path):
     store.create_ticket(_ticket("PLF-002", "done", age_days=1))
 
     assert [ticket.id for ticket in store.list_tickets(sprint="current")] == ["PLF-002"]
-    assert store.get_ticket("PLF-001").sprint == "archive-2026-07"
+    assert store.get_ticket("PLF-001").sprint == "history-2026-07-20"
+
+
+def test_stale_terminal_tickets_move_below_capacity_limits(tmp_path):
+    store = _store(
+        tmp_path,
+        max_current_tickets=100,
+        max_current_bytes=10_000_000,
+        retain_terminal_days=1,
+    )
+    yesterday = datetime.now(UTC) - timedelta(days=1)
+    today = datetime.now(UTC)
+
+    store.create_ticket(
+        Ticket(
+            id="PLF-001",
+            name="Yesterday",
+            status="done",
+            created_at=yesterday,
+            updated_at=yesterday,
+        )
+    )
+    store.create_ticket(
+        Ticket(
+            id="PLF-002",
+            name="Today",
+            status="done",
+            created_at=today,
+            updated_at=today,
+        )
+    )
+
+    assert [ticket.id for ticket in store.list_tickets(sprint="current")] == [
+        "PLF-002"
+    ]
+    history_name = f"history-{yesterday:%Y-%m-%d}"
+    assert [ticket.id for ticket in store.list_tickets(sprint=history_name)] == [
+        "PLF-001"
+    ]
+
+
+def test_history_is_partitioned_by_terminal_completion_day(tmp_path):
+    store = _store(tmp_path, retain_terminal_days=0)
+    two_days_ago = datetime.now(UTC) - timedelta(days=2)
+    yesterday = datetime.now(UTC) - timedelta(days=1)
+
+    for ticket_id, timestamp in (
+        ("PLF-001", two_days_ago),
+        ("PLF-002", yesterday),
+    ):
+        store.create_ticket(
+            Ticket(
+                id=ticket_id,
+                name=ticket_id,
+                status="done",
+                created_at=timestamp,
+                updated_at=timestamp,
+            )
+        )
+
+    assert store.get_ticket("PLF-001").sprint == f"history-{two_days_ago:%Y-%m-%d}"
+    assert store.get_ticket("PLF-002").sprint == f"history-{yesterday:%Y-%m-%d}"
+    assert len(store.list_tickets(sprint="all")) == 2
+
+
+def test_zero_day_retention_moves_fresh_terminal_ticket_immediately(tmp_path):
+    store = _store(tmp_path, retain_terminal_days=0)
+    now = datetime.now(UTC)
+
+    store.create_ticket(
+        Ticket(
+            id="PLF-001",
+            name="Freshly done",
+            status="done",
+            created_at=now,
+            updated_at=now,
+        )
+    )
+
+    assert store.list_tickets(sprint="current") == []
+    assert store.get_ticket("PLF-001").sprint == f"history-{now:%Y-%m-%d}"
+
+
+def test_active_lookup_does_not_parse_history_first(tmp_path, monkeypatch):
+    store = _store(tmp_path, retain_terminal_days=0)
+    yesterday = datetime.now(UTC) - timedelta(days=1)
+    store.create_ticket(
+        Ticket(
+            id="PLF-001",
+            name="Archived",
+            status="done",
+            created_at=yesterday,
+            updated_at=yesterday,
+        )
+    )
+    store.create_ticket(_ticket("PLF-002", "open"))
+    original = store._read_yaml_cached
+
+    def reject_history(path):
+        if path.stem.startswith("history-"):
+            raise AssertionError("active lookup parsed history before current")
+        return original(path)
+
+    monkeypatch.setattr(store, "_read_yaml_cached", reject_history)
+
+    assert store.get_ticket("PLF-002").sprint == "current"


### PR DESCRIPTION
## Outcome

- move terminal tickets into `history-YYYY-MM-DD` immediately by default
- run idempotent maintenance on API startup and once per UTC date
- preserve single/sharded YAML, legacy monthly archives, evidence and dependencies
- add bounded `history-locations.yaml` lookups and stale-snapshot resurrection guard
- prioritize operational sprint files before history scans

Tracks live Planfile ticket PLF-3774.

## Validation

- `pytest -q`: 360 passed, 6 skipped
- Ruff on changed Python/tests: passed
- Python compileall: passed
- todo2code deterministic workspace comparison: 0 blocking diagnostics
- focused todo2code NL extraction: 35 intent records with `z-ai/glm-5.2`, no degradation
- full todo2code run preserved 0 workspace blocking diagnostics; provider fallback was exercised safely on oversized responses

## Deployment safety

History destinations and the locator are written before source removal, so interruption may temporarily duplicate but cannot lose a ticket. Retry is idempotent.