### PR TITLE
fix(storage): bound legacy archive caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
   into `history-YYYY-MM-DD` files immediately by default. Added startup/daily
   maintenance, a lightweight history locator for bounded lookups, and stale
   snapshot protection so archived tickets cannot be resurrected by bulk sync.
+- Bounded worker memory by excluding YAML snapshots larger than 5 MB, including
+  legacy monthly archives, from parsed-data and ticket-model caches while
+  keeping those files readable on demand.
 - Fixed `planfile serve` install hint: Rich no longer swallows `[api]` as
   console markup, so the error now prints the correct
   `pip install 'planfile[api]'` instead of an extras-less command.

--- a/docs/guides/DAILY_TERMINAL_HISTORY.md
+++ b/docs/guides/DAILY_TERMINAL_HISTORY.md
@@ -27,7 +27,10 @@ daily file instead of parsing all history.
 The API runs an idempotent sweep on startup and once per UTC date, in addition
 to mutation-time rotation. Normal dashboard and watcher reads use
 `sprint=current`; callers use `sprint=all` only for an intentional full-history
-query. Existing `archive-YYYY-MM.yaml` files remain readable.
+query. Existing `archive-YYYY-MM.yaml` files remain readable. YAML snapshots up
+to 5 MB are cached for repeated reads; larger legacy snapshots are parsed on
+demand but not retained by long-running workers, preventing history scans from
+permanently increasing API memory usage.
 
 ## Acceptance requirements
 

--- a/planfile/core/store_files.py
+++ b/planfile/core/store_files.py
@@ -5,11 +5,22 @@ from typing import Any
 
 
 class StoreFileMixin:
+    # Keep hot operational and small daily-history snapshots cached, but do not
+    # pin legacy multi-megabyte archives in long-running API workers. Those
+    # files remain readable on demand and can be migrated independently.
+    MAX_CACHEABLE_YAML_BYTES = 5_000_000
+
     def _sprint_file(self, sprint: str) -> Path:
         return self.base_dir / f"{sprint}.yaml"
 
     def _all_sprint_files(self) -> list[Path]:
         return sorted(self.base_dir.glob("*.yaml"))
+
+    def _yaml_file_cacheable(self, path: Path) -> bool:
+        try:
+            return path.stat().st_size <= self.MAX_CACHEABLE_YAML_BYTES
+        except OSError:
+            return False
 
     def _read_yaml_cached(self, path: Path) -> dict[str, Any] | None:
         """Read a YAML sprint file with mtime-aware caching.
@@ -29,9 +40,17 @@ class StoreFileMixin:
             cached.pop(key, None)
             return None
         try:
-            mtime_ns = path.stat().st_mtime_ns
+            stat = path.stat()
+            mtime_ns = stat.st_mtime_ns
+            cacheable = stat.st_size <= self.MAX_CACHEABLE_YAML_BYTES
         except OSError:
             mtime_ns = -1
+            cacheable = False
+        if not cacheable:
+            cached.pop(key, None)
+            from planfile.core.fastio import read_yaml_fast
+
+            return read_yaml_fast(path)
         entry = cached.get(key)
         if entry is not None and entry[0] == mtime_ns:
             return entry[1]

--- a/planfile/core/store_tickets.py
+++ b/planfile/core/store_tickets.py
@@ -65,6 +65,9 @@ class TicketStoreMixin:
             cache = {}
             self._ticket_model_cache = cache
         key = str(sprint_file)
+        if not self._yaml_file_cacheable(sprint_file):
+            cache.pop(key, None)
+            return self._tickets_from_sprint_data(sprint_data)
         ticket_ids = (sprint_data.get('tickets') or {}).keys()
         evidence_revision = (
             self._ticket_evidence_revision(ticket_ids)

--- a/tests/test_ticket_archiving.py
+++ b/tests/test_ticket_archiving.py
@@ -45,6 +45,30 @@ def test_init_enables_bounded_automatic_archiving(tmp_path):
     assert config["archive"] == Store.DEFAULT_ARCHIVE_CONFIG
 
 
+def test_large_legacy_archive_models_are_not_retained(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    archived = _ticket("PLF-ARCHIVED", "done")
+    archived.sprint = "archive-legacy"
+    store.create_ticket(archived)
+    archive_file = store._sprint_file("archive-legacy")
+    store.MAX_CACHEABLE_YAML_BYTES = 1
+
+    validation_calls = {"n": 0}
+    original = store._ticket_from_data
+
+    def counting_validation(ticket_data):
+        validation_calls["n"] += 1
+        return original(ticket_data)
+
+    monkeypatch.setattr(store, "_ticket_from_data", counting_validation)
+
+    assert store._tickets_from_sprint_file(archive_file)[0].id == archived.id
+    assert store._tickets_from_sprint_file(archive_file)[0].id == archived.id
+    assert str(archive_file) not in store._yaml_cache
+    assert str(archive_file) not in store._ticket_model_cache
+    assert validation_calls["n"] == 2
+
+
 def test_archives_oldest_terminal_tickets_after_current_limit(tmp_path):
     store = _store(tmp_path)
     for number in range(1, 7):

--- a/tests/test_yaml_cache_invalidation.py
+++ b/tests/test_yaml_cache_invalidation.py
@@ -122,3 +122,28 @@ def test_missing_file_returns_none_without_caching(tmp_path: Path) -> None:
 
     assert store._read_yaml_cached(missing) is None
     assert store._read_yaml_cached(missing) is None
+
+
+def test_large_yaml_is_readable_but_not_retained_in_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sprint = tmp_path / "archive-legacy.yaml"
+    _write_sprint(sprint, {"sprint": {"id": "legacy", "tickets": {}}})
+    store = _Store(tmp_path)
+    store.MAX_CACHEABLE_YAML_BYTES = 1
+
+    from planfile.core import fastio
+
+    read_calls = {"n": 0}
+    real_read = fastio.read_yaml_fast
+
+    def counting_read(path: Path):
+        read_calls["n"] += 1
+        return real_read(path)
+
+    monkeypatch.setattr(fastio, "read_yaml_fast", counting_read)
+
+    assert store._read_yaml_cached(sprint)["sprint"]["id"] == "legacy"
+    assert store._read_yaml_cached(sprint)["sprint"]["id"] == "legacy"
+    assert str(sprint) not in store._yaml_cache
+    assert read_calls["n"] == 2


### PR DESCRIPTION
## Summary
- keep current and daily YAML snapshots cached up to 5 MB
- parse large legacy archives on demand without retaining parsed or Pydantic model caches
- document the memory boundary and add regression coverage

## Validation
- `pytest -q`: 362 passed, 6 skipped
- targeted Ruff: passed
- `git diff --check`: passed

Tracks PLF-3774.