### PR TITLE
fix(api): require an explicit full-history view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 - Bounded worker memory by excluding YAML snapshots larger than 5 MB, including
   legacy monthly archives, from parsed-data and ticket-model caches while
   keeping those files readable on demand.
+- Made full-history list reads explicit: `sprint=all` without a declared `view`
+  now returns the bounded current summary, preventing legacy service clients
+  from repeatedly materializing the complete archive.
 - Fixed `planfile serve` install hint: Rich no longer swallows `[api]` as
   console markup, so the error now prints the correct
   `pip install 'planfile[api]'` instead of an extras-less command.

--- a/docs/guides/DAILY_TERMINAL_HISTORY.md
+++ b/docs/guides/DAILY_TERMINAL_HISTORY.md
@@ -27,7 +27,10 @@ daily file instead of parsing all history.
 The API runs an idempotent sweep on startup and once per UTC date, in addition
 to mutation-time rotation. Normal dashboard and watcher reads use
 `sprint=current`; callers use `sprint=all` only for an intentional full-history
-query. Existing `archive-YYYY-MM.yaml` files remain readable. YAML snapshots up
+query and MUST also choose an explicit `view=summary`, `view=operational`, or
+`view=full`. For compatibility, an unqualified `sprint=all` is treated as a
+bounded current-summary request. Existing `archive-YYYY-MM.yaml` files remain
+readable. YAML snapshots up
 to 5 MB are cached for repeated reads; larger legacy snapshots are parsed on
 demand but not retained by long-running workers, preventing history scans from
 permanently increasing API memory usage.

--- a/planfile/api/server.py
+++ b/planfile/api/server.py
@@ -477,9 +477,11 @@ def list_tickets(
     if source:
         filters["source"] = source
     browser_client = "mozilla/" in request.headers.get("user-agent", "").lower()
+    explicit_view = "view" in request.query_params
+    legacy_unbounded_request = sprint == "all" and not explicit_view
     effective_view = (
         "summary"
-        if browser_client and "view" not in request.query_params
+        if (browser_client and not explicit_view) or legacy_unbounded_request
         else view
     )
     # Dashboards shipped before the bounded queue view requested `sprint=all`
@@ -488,7 +490,7 @@ def list_tickets(
     # intentionally needs the archive can opt in with an explicit `view`.
     effective_sprint = (
         "current"
-        if browser_client and "view" not in request.query_params and sprint == "all"
+        if legacy_unbounded_request
         else sprint
     )
     return _ticket_list_response(

--- a/tests/test_ticket_api_events.py
+++ b/tests/test_ticket_api_events.py
@@ -627,7 +627,7 @@ def test_ticket_list_pagination_headers(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "get_planfile", lambda: pf)
     client = TestClient(server.app)
 
-    response = client.get("/tickets?sprint=all&offset=1&limit=1")
+    response = client.get("/tickets?sprint=all&view=full&offset=1&limit=1")
 
     assert response.status_code == 200
     assert len(response.json()) == 1
@@ -743,7 +743,7 @@ def test_ticket_summary_view_keeps_queue_fields_and_omits_execution_contract(
     assert "history" not in payload
 
 
-def test_browser_without_explicit_view_gets_lightweight_summary(tmp_path, monkeypatch):
+def test_all_without_explicit_view_gets_bounded_current_summary(tmp_path, monkeypatch):
     pf = Planfile(str(tmp_path))
     current = pf.create_ticket(
         name="Browser queue",
@@ -776,6 +776,13 @@ def test_browser_without_explicit_view_gets_lightweight_summary(tmp_path, monkey
         "Browser queue",
         "Archived ticket",
     }
+
+    service_client = client.get(
+        "/tickets?sprint=all",
+        headers={"user-agent": "undici"},
+    )
+    assert service_client.headers["x-planfile-view"] == "summary"
+    assert [ticket["id"] for ticket in service_client.json()] == [current.id]
 
 
 def test_move_ticket_api_and_sprint_validation(tmp_path, monkeypatch):
@@ -1036,9 +1043,9 @@ def test_tickets_api_reads_updated_store_and_disables_cache(tmp_path, monkeypatc
     monkeypatch.setattr(server, "get_planfile", lambda: pf)
     client = TestClient(server.app)
 
-    first = client.get("/tickets?sprint=all")
+    first = client.get("/tickets?sprint=all&view=full")
     pf.complete_ticket(ticket.id, note="done outside API")
-    second = client.get("/tickets?sprint=all")
+    second = client.get("/tickets?sprint=all&view=full")
 
     assert first.headers["cache-control"] == "no-store, max-age=0"
     assert second.headers["cache-control"] == "no-store, max-age=0"
@@ -1173,7 +1180,7 @@ def test_evidence_append_invalidates_the_serialized_ticket_list_projection(
     monkeypatch.setattr(server, "get_planfile", lambda: pf)
     client = TestClient(server.app)
 
-    assert client.get("/tickets?sprint=all").json()[0].get("outputs") is None
+    assert client.get("/tickets?sprint=all&view=full").json()[0].get("outputs") is None
     response = client.post(
         f"/tickets/{ticket.id}/evidence",
         json={
@@ -1186,7 +1193,7 @@ def test_evidence_append_invalidates_the_serialized_ticket_list_projection(
     )
 
     assert response.status_code == 200
-    listed = client.get("/tickets?sprint=all").json()[0]
+    listed = client.get("/tickets?sprint=all&view=full").json()[0]
     assert listed["outputs"]["result"]["process_executions"][0]["execution_id"] == "projection-1"
 
 


### PR DESCRIPTION
## Summary
- treat unqualified `sprint=all` as a bounded current-summary request
- retain full-history access when callers explicitly select `view=summary`, `view=operational`, or `view=full`
- prevent legacy service clients from repeatedly materializing large archives

## Validation
- `pytest -q`: 362 passed, 6 skipped
- targeted Ruff: passed
- `git diff --check`: passed

Tracks PLF-3774 and follows live memory observation after #22.