### PR TITLE
feat: public forensic ticket event log DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### Added
+- Added a public, append-only `PLOG/1` forensic timeline in
+  `.planfile/events/logs.dsl.txt`, daily history partitions, bounded text/JSON
+  APIs, streaming backfill from SODL, and durable coverage for evidence and
+  management decisions. The compact projection keeps time, type, actor,
+  reason, lifecycle logic and correlation data directly readable by LLMs.
 - Added atomic `POST /tickets/{ticket_id}/evidence` for idempotent external-effect
   receipts. Retries after an ambiguous HTTP timeout now deduplicate under the
   store lock instead of requiring callers to replace the complete ticket output.

--- a/README.md
+++ b/README.md
@@ -374,6 +374,19 @@ snapshot protection do not need to parse every history file.
 See [Daily terminal history](docs/guides/DAILY_TERMINAL_HISTORY.md) for the
 ordering and compatibility contract.
 
+#### Public forensic event log
+
+Every ticket mutation, evidence append, configuration decision, and persisted
+management observation has a compact `PLOG/1` projection in
+`.planfile/events/logs.dsl.txt`. Previous UTC days live in daily history files.
+Applications and LLM tools can use the bounded public endpoints
+`GET /logs.dsl.txt`, `GET /logs`, and `GET /logs/days`, with optional
+`ticket_id`, `event_type`, `day`, and `limit` filters. PLOG keeps reasons,
+actors, state transitions, decisions, correlation IDs, and SODL event hashes
+readable while excluding large payloads. See
+[Public forensic log DSL](docs/guides/FORENSIC_LOG_DSL.md) for the grammar,
+retention layout, redaction, and API examples.
+
 The defaults apply to existing projects without a configuration change. They
 can be adjusted or disabled through the validated configuration interface (or
 reviewed directly in `.planfile/config.yaml`):

--- a/docs/guides/FORENSIC_LOG_DSL.md
+++ b/docs/guides/FORENSIC_LOG_DSL.md
@@ -1,0 +1,81 @@
+# Public forensic log DSL
+
+Planfile exposes a compact, append-only event timeline for applications,
+operators, autonomous reviewers, and LLM diagnostics. The current UTC day is
+stored in:
+
+```text
+.planfile/events/logs.dsl.txt
+```
+
+Older days are moved to
+`.planfile/events/history/logs-YYYY-MM-DD.dsl.txt`. Consumers should normally
+use the public HTTP interface rather than require access to Planfile's volume:
+
+```bash
+curl http://localhost:8000/logs.dsl.txt
+curl 'http://localhost:8000/logs.dsl.txt?ticket_id=PLF-3775&limit=200'
+curl 'http://localhost:8000/logs?event_type=ticket.status_change&limit=100'
+curl http://localhost:8000/logs/days
+curl 'http://localhost:8000/logs.dsl.txt?day=2026-08-04&limit=5000'
+```
+
+Both text and JSON reads are bounded to at most 5000 records. Text responses
+declare `X-Planfile-Log-Format: PLOG/1`, the selected UTC date, and the result
+count. `/logs/days` lists the available partitions and byte sizes without
+exposing server filesystem paths.
+
+## PLOG/1 format
+
+Each physical line is one event. Fields are separated by tabs, and every value
+is canonical JSON. This keeps values unambiguous while leaving reasons and
+decisions directly readable without decoding a payload:
+
+```text
+PLOG/1 timestamp="2026-08-05T10:51:37Z" event_id="evt_..." event_hash="2ae..." type="ticket.status_change" kind="task" ticket_id="PLF-3774" actor="codex" source="planfile.history" mode="apply" status="done" correlation_id="PLF-3774" causation_id="-" receipt_ref="-" replayable=true logic={"reason":"All checks passed.","changes":["status"],"previous_status":"open","status":"done","execution_state":"done"}
+```
+
+The actual file uses tab separators. The fixed fields are:
+
+- `timestamp`, `event_id`, and `event_hash` for ordering and verification;
+- `type` for the OQL operation, such as `ticket.create`, `ticket.update`,
+  `ticket.status_change`, `ticket.evidence.append`, or a management event;
+- `ticket_id`, `actor`, `source`, `mode`, and `status` for attribution;
+- `correlation_id`, `causation_id`, and `receipt_ref` for tracing;
+- `replayable` to distinguish commands from observations;
+- `logic`, a bounded projection of fields useful for diagnosis: name,
+  priority, reason, decision, changes, previous/current lifecycle states,
+  outcome, error, message, queue, evidence collection, and idempotency key.
+
+Secret-like keys and credential-looking strings are redacted by SODL before
+the PLOG projection is created. Large descriptions, raw tool output, and full
+evidence payloads are deliberately excluded so one noisy event cannot make LLM
+context unbounded.
+
+## Relationship to SODL and OQL
+
+PLOG does not replace the existing audit contract:
+
+- OQL describes the operation or decision being applied.
+- SODL/1 in `.planfile/events/operations.jsonl` is the complete canonical,
+  hashed event and retains the redacted source payload.
+- PLOG/1 is the compact forensic index. Its `event_id` and `event_hash` point
+  back to the full SODL event.
+- Per-ticket evidence JSONL remains the durable source of external receipts;
+  PLOG records that a receipt was appended, why, by whom, and under which
+  idempotency key.
+
+On first use, existing `operations.jsonl` is streamed line by line into daily
+PLOG partitions. The migration does not load the complete journal into memory.
+New operational events write PLOG first and then the backwards-compatible JSONL
+projection. Daily rotation and both appends run under the existing Planfile
+mutation lock.
+
+## Event coverage
+
+The durable log covers ticket creation, updates, lifecycle transitions, moves,
+deletions, evidence appends, configuration decisions, externally observed
+ticket changes, API startup, daily-history maintenance, management-event
+ingestion, and synthetic diagnostic events. WebSocket messages derived from an
+already recorded ticket mutation are not duplicated; their source mutation is
+the forensic event.

--- a/planfile/__init__.py
+++ b/planfile/__init__.py
@@ -80,6 +80,7 @@ class Planfile:
         self.store = PlanfileStore(project_path)
         if not self.store.is_initialized():
             self.store.init()
+        self.store.ensure_forensic_log_projection()
 
     @property
     def configuration(self):

--- a/planfile/api/server.py
+++ b/planfile/api/server.py
@@ -31,7 +31,7 @@ try:
         WebSocketDisconnect,
     )
     from fastapi.middleware.cors import CORSMiddleware
-    from fastapi.responses import HTMLResponse, JSONResponse, Response
+    from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
     from pydantic import BaseModel, Field
 except ImportError as exc:
     raise ImportError("FastAPI required: pip install 'fastapi[all]' uvicorn") from exc
@@ -558,6 +558,68 @@ def list_operational_events(
     return {"ok": True, "ticket_id": ticket_id, "operations": get_planfile().store.operational_events(limit=limit, ticket_id=ticket_id)}
 
 
+@app.get("/logs.dsl.txt", response_class=PlainTextResponse, tags=["observability"])
+def public_forensic_log(
+    ticket_id: str | None = Query(None),
+    event_type: str | None = Query(None),
+    day: str | None = Query(None, pattern=r"^\d{4}-\d{2}-\d{2}$"),
+    limit: int = Query(500, ge=1, le=5000),
+):
+    """Bounded PLOG/1 text projection for applications, operators and LLMs."""
+    selected_day = day or datetime.now(UTC).date().isoformat()
+    lines = get_planfile().store.forensic_log_lines(
+        date=selected_day,
+        ticket_id=ticket_id,
+        event_type=event_type,
+        limit=limit,
+    )
+    return PlainTextResponse(
+        "".join(f"{line}\n" for line in lines),
+        headers={
+            **NO_STORE_HEADERS,
+            "X-Planfile-Log-Format": "PLOG/1",
+            "X-Planfile-Log-Date": selected_day,
+            "X-Result-Count": str(len(lines)),
+        },
+    )
+
+
+@app.get("/logs", tags=["observability"])
+def public_forensic_log_json(
+    ticket_id: str | None = Query(None),
+    event_type: str | None = Query(None),
+    day: str | None = Query(None, pattern=r"^\d{4}-\d{2}-\d{2}$"),
+    limit: int = Query(500, ge=1, le=5000),
+):
+    """Parsed PLOG/1 records with the same bounded filters as the text file."""
+    from planfile.core.forensic_log_dsl import parse
+
+    selected_day = day or datetime.now(UTC).date().isoformat()
+    lines = get_planfile().store.forensic_log_lines(
+        date=selected_day,
+        ticket_id=ticket_id,
+        event_type=event_type,
+        limit=limit,
+    )
+    return {
+        "schema": "planfile.forensic-log-response/v1",
+        "format": "PLOG/1",
+        "date": selected_day,
+        "count": len(lines),
+        "events": [parse(line) for line in lines],
+    }
+
+
+@app.get("/logs/days", tags=["observability"])
+def public_forensic_log_days():
+    """List available daily PLOG partitions without exposing storage paths."""
+    return {
+        "schema": "planfile.forensic-log-days/v1",
+        "format": "PLOG/1",
+        "days": get_planfile().store.forensic_log_days(),
+    }
+
+
 @app.patch("/tickets/{ticket_id}", tags=["tickets"])
 async def update_ticket(ticket_id: str, body: TicketUpdate):
     pf = get_planfile()
@@ -1064,6 +1126,20 @@ def _remember_event(event: dict[str, Any]) -> None:
     _event_history.append(event)
 
 
+def _remember_durable_event(event: dict[str, Any]) -> None:
+    """Keep the dashboard event and its compact durable forensic projection."""
+    _remember_event(event)
+    append = getattr(get_planfile().store, "append_management_event", None)
+    if not callable(append):
+        return
+    try:
+        append(event)
+    except Exception as exc:  # pragma: no cover - logging must not mask the event
+        __import__("logging").getLogger("planfile.api").warning(
+            "forensic management event was not persisted: %s", exc
+        )
+
+
 def _ticket_signature(ticket) -> str:
     data = ticket.model_dump(mode="json", exclude_none=True)
     execution = data.get("execution") or {}
@@ -1157,7 +1233,7 @@ async def _archive_history_daily(interval_seconds: float = 300.0) -> None:
                     get_planfile().store.archive_completed
                 )
             except Exception as exc:  # pragma: no cover - defensive runtime telemetry
-                _remember_event(
+                _remember_durable_event(
                     {
                         "type": "management.event",
                         "action": "daily-history-error",
@@ -1174,7 +1250,7 @@ async def _archive_history_daily(interval_seconds: float = 300.0) -> None:
             else:
                 last_run_date = today
                 if report.get("archived"):
-                    _remember_event(
+                    _remember_durable_event(
                         {
                             "type": "management.event",
                             "action": "daily-history",
@@ -1213,7 +1289,7 @@ async def _stop_archive_maintenance() -> None:
 
 async def _start_planfile_watcher() -> None:
     global _watch_task
-    _remember_event(
+    _remember_durable_event(
         {
             "type": "management.event",
             "action": "started",
@@ -1283,7 +1359,7 @@ async def create_test_event(body: TestEventRequest):
             },
         },
     }
-    _remember_event(payload)
+    _remember_durable_event(payload)
     await _manager.broadcast(payload)
     return payload
 
@@ -1308,7 +1384,7 @@ async def ingest_management_event(body: ManagementEventRequest):
         "message": body.message,
         "details": details,
     }
-    _remember_event(payload)
+    _remember_durable_event(payload)
     await _manager.broadcast(payload)
     return payload
 
@@ -3013,7 +3089,10 @@ async def _broadcast_ticket_event(
     if ticket is not None:
         payload["ticket"] = ticket.model_dump(mode="json", exclude_none=True)
         _watch_snapshot[ticket.id] = _ticket_signature(ticket)
-    _remember_event(payload)
+    if event_type.startswith("ticket.external."):
+        _remember_durable_event(payload)
+    else:
+        _remember_event(payload)
     await _manager.broadcast(payload)
 
 

--- a/planfile/core/forensic_log_dsl.py
+++ b/planfile/core/forensic_log_dsl.py
@@ -1,0 +1,127 @@
+"""Compact, human- and LLM-readable projection of Planfile SODL events."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+PREFIX = "PLOG/1"
+SCHEMA = "planfile.forensic-log/v1"
+
+_LOGIC_KEYS = (
+    "name",
+    "priority",
+    "reason",
+    "decision",
+    "action",
+    "changes",
+    "previous_status",
+    "status",
+    "previous_execution_state",
+    "execution_state",
+    "outcome",
+    "error",
+    "message",
+    "level",
+    "queue",
+    "collection",
+    "idempotency_key",
+)
+
+
+def _bounded(value: Any) -> Any:
+    if isinstance(value, str):
+        return value[:2000]
+    if isinstance(value, list):
+        return [_bounded(item) for item in value[:30]]
+    if isinstance(value, dict):
+        return {str(key): _bounded(item) for key, item in list(value.items())[:30]}
+    return value
+
+
+def _logic(event: dict[str, Any]) -> dict[str, Any]:
+    data = event.get("data") if isinstance(event.get("data"), dict) else {}
+    payload = data.get("payload") if isinstance(data.get("payload"), dict) else data
+    logic = {
+        key: _bounded(payload[key])
+        for key in _LOGIC_KEYS
+        if key in payload and payload[key] not in (None, "", [], {})
+    }
+    if "status" not in logic and event.get("status") not in (None, "", "recorded"):
+        logic["status"] = event["status"]
+    return logic
+
+
+def project(event: dict[str, Any]) -> dict[str, Any]:
+    """Return the bounded forensic fields that explain one operational event."""
+    return {
+        "schema": SCHEMA,
+        "timestamp": str(event.get("timestamp") or "-"),
+        "event_id": str(event.get("event_id") or "-"),
+        "event_hash": str(event.get("event_hash") or "-"),
+        "type": str(event.get("oql") or "observe"),
+        "kind": str(event.get("kind") or "operation"),
+        "ticket_id": str(event.get("ticket_id") or "-"),
+        "actor": str(event.get("actor") or "system"),
+        "source": str(event.get("source") or "planfile"),
+        "mode": str(event.get("mode") or "observe"),
+        "status": str(event.get("status") or "recorded"),
+        "correlation_id": str(event.get("correlation_id") or "-"),
+        "causation_id": str(event.get("causation_id") or "-"),
+        "receipt_ref": str(event.get("receipt_ref") or "-"),
+        "replayable": event.get("replayable") is not False,
+        "logic": _logic(event),
+    }
+
+
+_FIELDS = (
+    "timestamp",
+    "event_id",
+    "event_hash",
+    "type",
+    "kind",
+    "ticket_id",
+    "actor",
+    "source",
+    "mode",
+    "status",
+    "correlation_id",
+    "causation_id",
+    "receipt_ref",
+    "replayable",
+    "logic",
+)
+
+
+def serialize(event: dict[str, Any]) -> str:
+    """Serialize one event as tab-delimited JSON values on a single line."""
+    record = project(event)
+    fields = [
+        f"{key}={json.dumps(record[key], ensure_ascii=False, separators=(',', ':'))}"
+        for key in _FIELDS
+    ]
+    return f"{PREFIX}\t" + "\t".join(fields)
+
+
+def parse(line: str) -> dict[str, Any]:
+    raw = str(line or "").rstrip("\r\n")
+    if not raw.startswith(f"{PREFIX}\t"):
+        raise ValueError("plog_prefix_invalid")
+    values: dict[str, Any] = {"schema": SCHEMA}
+    for token in raw.split("\t")[1:]:
+        if "=" not in token:
+            raise ValueError("plog_field_invalid")
+        key, encoded = token.split("=", 1)
+        try:
+            values[key] = json.loads(encoded)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"plog_value_invalid:{key}") from exc
+    if missing := set(_FIELDS) - values.keys():
+        raise ValueError(f"plog_field_required:{sorted(missing)[0]}")
+    canonical = f"{PREFIX}\t" + "\t".join(
+        f"{key}={json.dumps(values[key], ensure_ascii=False, separators=(',', ':'))}"
+        for key in _FIELDS
+    )
+    if canonical != raw:
+        raise ValueError("plog_line_not_canonical")
+    return values

--- a/planfile/core/store.py
+++ b/planfile/core/store.py
@@ -50,6 +50,10 @@ class Store(StoreFileMixin, TicketStoreMixin):
         self._sprints_dir = self.base_dir / "sprints"
         self._lock_path = self.base_dir / ".store.lock"
         self._operations_path = self.base_dir / "events" / "operations.jsonl"
+        self._forensic_log_path = self.base_dir / "events" / "logs.dsl.txt"
+        self._forensic_log_history_dir = self.base_dir / "events" / "history"
+        self._forensic_log_date_path = self.base_dir / "events" / ".logs.dsl.date"
+        self._forensic_log_receipt_path = self.base_dir / "events" / ".logs.dsl.v1"
         self._evidence_dir = self.base_dir / "evidence"
         self._ticket_index_path = self.base_dir / "index" / "tickets.sqlite3"
         self._history_locations_path = self.base_dir / "index" / "history-locations.yaml"
@@ -99,8 +103,10 @@ class Store(StoreFileMixin, TicketStoreMixin):
         from planfile.core.operational_dsl import parse
 
         rows = []
+        events = []
         for line in lines:
             event = parse(line)
+            events.append(event)
             rows.append(
                 json.dumps(
                     {"schema": event["schema"], "event": event, "dsl": line},
@@ -110,11 +116,208 @@ class Store(StoreFileMixin, TicketStoreMixin):
             )
         if not rows:
             return
+        self._ensure_forensic_log_projection_unlocked()
+        self._append_forensic_events_unlocked(events)
         self._operations_path.parent.mkdir(parents=True, exist_ok=True)
         with self._operations_path.open("a", encoding="utf-8") as handle:
             handle.write("".join(f"{row}\n" for row in rows))
             handle.flush()
             os.fsync(handle.fileno())
+
+    @staticmethod
+    def _forensic_event_date(event: dict) -> str:
+        value = str(event.get("timestamp") or "")[:10]
+        try:
+            return datetime.fromisoformat(value).date().isoformat()
+        except ValueError:
+            return datetime.now(UTC).date().isoformat()
+
+    def _forensic_path_for_date(self, value: str) -> Path:
+        today = datetime.now(UTC).date().isoformat()
+        if value == today:
+            return self._forensic_log_path
+        return self._forensic_log_history_dir / f"logs-{value}.dsl.txt"
+
+    def _rotate_forensic_log_unlocked(self) -> None:
+        today = datetime.now(UTC).date().isoformat()
+        try:
+            recorded_date = self._forensic_log_date_path.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            recorded_date = ""
+        if recorded_date and recorded_date != today and self._forensic_log_path.exists():
+            destination = self._forensic_log_history_dir / f"logs-{recorded_date}.dsl.txt"
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with destination.open("a", encoding="utf-8") as output:
+                with self._forensic_log_path.open("r", encoding="utf-8") as source:
+                    shutil.copyfileobj(source, output)
+                output.flush()
+                os.fsync(output.fileno())
+            self._forensic_log_path.unlink()
+        self._forensic_log_path.parent.mkdir(parents=True, exist_ok=True)
+        self._forensic_log_path.touch(exist_ok=True)
+        from planfile.core.fastio import _atomic_write_text
+
+        _atomic_write_text(self._forensic_log_date_path, f"{today}\n")
+
+    def _append_forensic_events_unlocked(self, events: list[dict]) -> None:
+        from planfile.core.forensic_log_dsl import serialize as forensic_line
+
+        self._rotate_forensic_log_unlocked()
+        grouped: dict[Path, list[str]] = {}
+        for event in events:
+            path = self._forensic_path_for_date(self._forensic_event_date(event))
+            grouped.setdefault(path, []).append(forensic_line(event))
+        for path, projected in grouped.items():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write("".join(f"{line}\n" for line in projected))
+                handle.flush()
+                os.fsync(handle.fileno())
+
+    def _ensure_forensic_log_projection_unlocked(self) -> None:
+        if self._forensic_log_receipt_path.exists():
+            self._rotate_forensic_log_unlocked()
+            return
+        self._rotate_forensic_log_unlocked()
+        if self._operations_path.exists():
+            batch = []
+            with self._operations_path.open("r", encoding="utf-8") as source:
+                for raw in source:
+                    if not raw.strip():
+                        continue
+                    try:
+                        row = json.loads(raw)
+                    except ValueError:
+                        continue
+                    event = row.get("event") if isinstance(row, dict) else None
+                    if isinstance(event, dict):
+                        batch.append(event)
+                    if len(batch) >= 250:
+                        self._append_forensic_events_unlocked(batch)
+                        batch.clear()
+            if batch:
+                self._append_forensic_events_unlocked(batch)
+        from planfile.core.fastio import _atomic_write_text
+
+        _atomic_write_text(
+            self._forensic_log_receipt_path,
+            "schema=planfile.forensic-log-projection/v1\n",
+        )
+
+    def ensure_forensic_log_projection(self) -> None:
+        """Backfill the compact public log once, then keep it append-only."""
+        if self._forensic_log_receipt_path.exists():
+            try:
+                recorded_date = self._forensic_log_date_path.read_text(
+                    encoding="utf-8"
+                ).strip()
+            except FileNotFoundError:
+                recorded_date = ""
+            if recorded_date == datetime.now(UTC).date().isoformat():
+                return
+        with self.mutation_lock():
+            self._ensure_forensic_log_projection_unlocked()
+
+    def forensic_log_lines(
+        self,
+        *,
+        date: str | None = None,
+        ticket_id: str | None = None,
+        event_type: str | None = None,
+        limit: int = 500,
+    ) -> list[str]:
+        """Return a bounded oldest-to-newest slice of the readable log."""
+        from collections import deque
+
+        from planfile.core.forensic_log_dsl import parse
+
+        self.ensure_forensic_log_projection()
+        selected_date = date or datetime.now(UTC).date().isoformat()
+        path = self._forensic_path_for_date(selected_date)
+        result: deque[str] = deque(maxlen=max(1, min(int(limit), 5000)))
+        try:
+            source = path.open("r", encoding="utf-8")
+        except FileNotFoundError:
+            return []
+        with source:
+            for raw in source:
+                line = raw.rstrip("\r\n")
+                if not line:
+                    continue
+                if ticket_id or event_type:
+                    try:
+                        record = parse(line)
+                    except ValueError:
+                        continue
+                    if ticket_id and record["ticket_id"] != ticket_id:
+                        continue
+                    if event_type and record["type"] != event_type:
+                        continue
+                result.append(line)
+        return list(result)
+
+    def forensic_log_days(self) -> list[dict]:
+        """Describe every public daily PLOG partition, newest first."""
+        self.ensure_forensic_log_projection()
+        today = datetime.now(UTC).date().isoformat()
+        paths = [(today, self._forensic_log_path)]
+        for path in self._forensic_log_history_dir.glob("logs-*.dsl.txt"):
+            paths.append((path.name.removeprefix("logs-").removesuffix(".dsl.txt"), path))
+        result = []
+        for value, path in sorted(paths, reverse=True):
+            try:
+                stat = path.stat()
+            except FileNotFoundError:
+                continue
+            result.append({"date": value, "bytes": stat.st_size, "file": path.name})
+        return result
+
+    def append_management_event(self, event: dict) -> None:
+        """Persist a compact management observation in the same audit stream."""
+        from planfile.core.operational_dsl import line as operational_line
+
+        ticket_id = str(event.get("ticket_id") or "-")
+        action = str(event.get("action") or event.get("type") or "observe")
+        source = str(event.get("source") or event.get("tool") or "planfile.api")
+        actor = str(event.get("actor") or event.get("tool") or source)
+        ticket = event.get("ticket") if isinstance(event.get("ticket"), dict) else {}
+        execution = ticket.get("execution") if isinstance(ticket.get("execution"), dict) else {}
+        details = event.get("details") if isinstance(event.get("details"), dict) else {}
+        message = str(
+            event.get("message")
+            or execution.get("last_error")
+            or details.get("error")
+            or ""
+        )
+        data = {
+            "payload": {
+                "action": action,
+                "name": str(ticket.get("name") or ""),
+                "message": message,
+                "level": str(event.get("level") or "info"),
+                "queue": str(event.get("queue") or execution.get("queue") or "default"),
+                "reason": str(event.get("reason") or message),
+                "status": str(ticket.get("status") or event.get("status") or "recorded"),
+                "execution_state": str(execution.get("state") or ""),
+            }
+        }
+        with self.mutation_lock():
+            self._append_operational_line(
+                operational_line(
+                    timestamp=event.get("created_at"),
+                    kind="management",
+                    source=source,
+                    ticket_id=ticket_id,
+                    actor=actor,
+                    oql=f"event.{action}",
+                    uri=f"planfile://events/{action}/observe",
+                    mode="observe",
+                    status=str(ticket.get("status") or event.get("status") or "recorded"),
+                    correlation_id=str(event.get("correlation_id") or ticket_id),
+                    replayable=False,
+                    data=data,
+                )
+            )
 
     def _ticket_evidence_path(self, ticket_id: str) -> Path:
         value = str(ticket_id or "").strip()
@@ -235,13 +438,25 @@ class Store(StoreFileMixin, TicketStoreMixin):
 
     def operational_events(self, *, limit: int = 200, ticket_id: str | None = None) -> list[dict]:
         """Read the append-only operational journal, newest first."""
+        from collections import deque
+
+        bounded: deque[dict] = deque(maxlen=max(1, min(int(limit), 5000)))
         try:
-            rows = [json.loads(line) for line in self._operations_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+            source = self._operations_path.open("r", encoding="utf-8")
         except FileNotFoundError:
             return []
-        if ticket_id:
-            rows = [row for row in rows if str((row.get("event") or {}).get("ticket_id") or "") == str(ticket_id)]
-        return list(reversed(rows[-max(1, min(int(limit), 5000)) :]))
+        with source:
+            for line in source:
+                if not line.strip():
+                    continue
+                try:
+                    row = json.loads(line)
+                except ValueError:
+                    continue
+                if ticket_id and str((row.get("event") or {}).get("ticket_id") or "") != str(ticket_id):
+                    continue
+                bounded.append(row)
+        return list(reversed(bounded))
 
     @contextmanager
     def mutation_lock(self):
@@ -1652,6 +1867,32 @@ class Store(StoreFileMixin, TicketStoreMixin):
                 "reason": str(reason),
             }
             self._append_ticket_evidence_event(ticket_id, event)
+            from planfile.core.operational_dsl import line as operational_line
+
+            self._append_operational_line(
+                operational_line(
+                    timestamp=timestamp,
+                    kind="evidence",
+                    source="planfile.evidence",
+                    ticket_id=ticket_id,
+                    actor=str(actor),
+                    oql="ticket.evidence.append",
+                    uri=f"planfile://tickets/{ticket_id}/evidence/{collection}/append",
+                    mode="apply",
+                    status="recorded",
+                    correlation_id=ticket_id,
+                    receipt_ref=f"evidence://{ticket_id}/{key}",
+                    replayable=False,
+                    data={
+                        "payload": {
+                            "collection": collection,
+                            "idempotency_key": key,
+                            "reason": str(reason),
+                            "evidence_keys": sorted(serialized_evidence),
+                        }
+                    },
+                )
+            )
             projected = self._apply_ticket_evidence_events(
                 current.model_dump(mode="json", exclude_none=True),
                 [event],

--- a/tests/test_forensic_log_dsl.py
+++ b/tests/test_forensic_log_dsl.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+from planfile import Planfile, TicketSource
+from planfile.api import server
+from planfile.core.forensic_log_dsl import parse as parse_log
+from planfile.core.forensic_log_dsl import serialize as serialize_log
+from planfile.core.operational_dsl import line as operational_line
+from planfile.core.operational_dsl import parse as parse_operational
+
+
+def test_plog_is_compact_readable_and_round_trips() -> None:
+    event = parse_operational(
+        operational_line(
+            timestamp="2026-08-05T12:00:00Z",
+            kind="task",
+            source="planfile.history",
+            ticket_id="PLF-1",
+            actor="bot:reviewer",
+            oql="ticket.status_change",
+            status="done",
+            data={
+                "payload": {
+                    "reason": "Review passed",
+                    "changes": ["status"],
+                    "previous_status": "in_progress",
+                    "status": "done",
+                    "large_unneeded_result": "x" * 20_000,
+                }
+            },
+        )
+    )
+
+    line = serialize_log(event)
+    parsed = parse_log(line)
+
+    assert line.startswith("PLOG/1\t")
+    assert '"Review passed"' in line
+    assert "large_unneeded_result" not in line
+    assert len(line) < 1500
+    assert parsed["ticket_id"] == "PLF-1"
+    assert parsed["type"] == "ticket.status_change"
+    assert parsed["logic"] == {
+        "reason": "Review passed",
+        "changes": ["status"],
+        "previous_status": "in_progress",
+        "status": "done",
+    }
+
+
+def test_ticket_lifecycle_and_evidence_are_written_to_public_log(tmp_path) -> None:
+    pf = Planfile(str(tmp_path))
+    ticket = pf.create_ticket(name="Forensic lifecycle", source=TicketSource(tool="test"))
+    pf.update_ticket(ticket.id, priority="high", actor="bot:test", reason="Triage decision")
+    _, recorded = pf.append_ticket_evidence(
+        ticket.id,
+        idempotency_key="proof-1",
+        collection="checks",
+        evidence={"id": "proof-1", "passed": True},
+        actor="bot:validator",
+        reason="Independent check passed",
+    )
+
+    records = [parse_log(line) for line in pf.store.forensic_log_lines(ticket_id=ticket.id)]
+
+    assert recorded is True
+    assert [record["type"] for record in records] == [
+        "ticket.create",
+        "ticket.update",
+        "ticket.evidence.append",
+    ]
+    assert records[1]["logic"]["reason"] == "Triage decision"
+    assert records[2]["logic"] == {
+        "reason": "Independent check passed",
+        "collection": "checks",
+        "idempotency_key": "proof-1",
+    }
+    assert pf.store._forensic_log_path.exists()
+
+
+def test_historical_events_are_partitioned_by_utc_day(tmp_path) -> None:
+    pf = Planfile(str(tmp_path))
+    yesterday = datetime.now(UTC) - timedelta(days=1)
+    with pf.store.mutation_lock():
+        pf.store._append_operational_line(
+            operational_line(
+                timestamp=yesterday.isoformat(),
+                ticket_id="PLF-OLD",
+                actor="migration",
+                oql="ticket.update",
+                status="done",
+                data={"payload": {"reason": "Historical migration"}},
+            )
+        )
+
+    lines = pf.store.forensic_log_lines(
+        date=yesterday.date().isoformat(),
+        ticket_id="PLF-OLD",
+    )
+
+    assert len(lines) == 1
+    assert parse_log(lines[0])["logic"]["reason"] == "Historical migration"
+    assert (
+        pf.store._forensic_log_history_dir
+        / f"logs-{yesterday.date().isoformat()}.dsl.txt"
+    ).exists()
+
+
+def test_first_read_on_new_utc_day_rotates_the_public_file(tmp_path) -> None:
+    pf = Planfile(str(tmp_path))
+    yesterday = datetime.now(UTC) - timedelta(days=1)
+    event = parse_operational(
+        operational_line(
+            timestamp=yesterday.isoformat(),
+            ticket_id="PLF-YESTERDAY",
+            actor="test",
+            oql="ticket.update",
+            data={"payload": {"reason": "Previous UTC day"}},
+        )
+    )
+    pf.store._forensic_log_path.write_text(f"{serialize_log(event)}\n", encoding="utf-8")
+    pf.store._forensic_log_date_path.write_text(
+        f"{yesterday.date().isoformat()}\n", encoding="utf-8"
+    )
+
+    assert pf.store.forensic_log_lines() == []
+    historical = pf.store.forensic_log_lines(date=yesterday.date().isoformat())
+
+    assert len(historical) == 1
+    assert parse_log(historical[0])["ticket_id"] == "PLF-YESTERDAY"
+
+
+def test_existing_jsonl_is_backfilled_without_read_text(tmp_path, monkeypatch) -> None:
+    pf = Planfile(str(tmp_path))
+    ticket = pf.create_ticket(name="Legacy operation", source=TicketSource(tool="test"))
+    pf.store._forensic_log_path.unlink()
+    pf.store._forensic_log_receipt_path.unlink()
+
+    original_read_text = type(pf.store._operations_path).read_text
+
+    def guarded_read_text(path, *args, **kwargs):
+        if path == pf.store._operations_path:
+            raise AssertionError("operations.jsonl must be streamed")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(type(pf.store._operations_path), "read_text", guarded_read_text)
+    pf.store.ensure_forensic_log_projection()
+
+    records = [parse_log(line) for line in pf.store.forensic_log_lines(ticket_id=ticket.id)]
+    assert [record["type"] for record in records] == ["ticket.create"]
+    assert pf.store.operational_events(ticket_id=ticket.id, limit=1)[0]["event"][
+        "ticket_id"
+    ] == ticket.id
+
+
+def test_public_text_and_json_log_endpoints_and_management_ingest(tmp_path, monkeypatch) -> None:
+    pf = Planfile(str(tmp_path))
+    ticket = pf.create_ticket(name="Public log", source=TicketSource(tool="test"))
+    monkeypatch.setattr(server, "get_planfile", lambda: pf)
+    client = TestClient(server.app)
+
+    text_response = client.get(f"/logs.dsl.txt?ticket_id={ticket.id}&limit=10")
+    json_response = client.get(f"/logs?ticket_id={ticket.id}&limit=10")
+    ingested = client.post(
+        "/events/ingest",
+        json={
+            "action": "review-decision",
+            "ticket_id": ticket.id,
+            "source": "validator-agent",
+            "tool": "validator-agent",
+            "status": "accepted",
+            "message": "Autonomous review accepted the change.",
+        },
+    )
+
+    assert text_response.status_code == 200
+    assert text_response.headers["x-planfile-log-format"] == "PLOG/1"
+    assert text_response.text.startswith("PLOG/1\t")
+    assert json_response.json()["events"][0]["type"] == "ticket.create"
+    days = client.get("/logs/days").json()["days"]
+    assert days[0]["file"] == "logs.dsl.txt"
+    assert days[0]["bytes"] > 0
+    assert ingested.status_code == 200
+    durable = client.get(
+        f"/logs?ticket_id={ticket.id}&event_type=event.review-decision"
+    ).json()
+    assert durable["count"] == 1
+    assert durable["events"][0]["logic"]["message"] == (
+        "Autonomous review accepted the change."
+    )


### PR DESCRIPTION
## Summary
- expose compact append-only PLOG/1 ticket and management event history through `/logs.dsl.txt`, `/logs`, and `/logs/days`
- rotate the public projection by UTC day and stream the existing SODL journal during first-use backfill
- record evidence and management decisions while retaining the canonical SODL audit trail
- document the grammar, redaction, retention, and API contract

## Validation
- `pytest -q`: 368 passed, 6 skipped
- Ruff: changed Python modules pass
- `git diff --check`
- todo2code: 0 blocking diagnostics, `z-ai/glm-5.2` via OpenRouter/Fireworks, no degraded LLM stage
- live-journal benchmark: 82 MB backfill in 1.85 s, 58 MB peak RSS

Planfile ticket: PLF-3775