### PR TITLE
fix: bound indexed full-history reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+- Serialized stale SQLite index rebuilds across readers and serve full and
+  operational ticket lists directly from the index, avoiding concurrent archive
+  materialization, SQLite reset races, and multi-gigabyte model caches.
+
 ### Added
 - Added a public, append-only `PLOG/1` forensic timeline in
   `.planfile/events/logs.dsl.txt`, daily history partitions, bounded text/JSON

--- a/planfile/api/server.py
+++ b/planfile/api/server.py
@@ -339,7 +339,11 @@ def _ticket_operational_payload(ticket) -> dict[str, Any]:
     dependencies and the executable process contract, but not an ever-growing
     journal of history, human notes or artifact references on every poll.
     """
-    payload = ticket.model_dump(mode="json", exclude_none=True)
+    payload = (
+        ticket.model_dump(mode="json", exclude_none=True)
+        if hasattr(ticket, "model_dump")
+        else dict(ticket)
+    )
     for field in ("history", "dsl", "file", "files", "integration", "llm_hints", "sync"):
         payload.pop(field, None)
     source = payload.get("source")
@@ -416,14 +420,33 @@ def _ticket_list_response(
         if cached is not None:
             body, total, count = cached
         else:
-            if view == "summary" and pf.store.ticket_index_enabled():
-                payload, total = pf.store.indexed_ticket_summaries(
-                    sprint=sprint,
-                    filters=filters,
-                    offset=offset,
-                    limit=limit,
-                )
-                count = len(payload)
+            body = None
+            if pf.store.ticket_index_enabled():
+                if view == "summary":
+                    payload, total = pf.store.indexed_ticket_summaries(
+                        sprint=sprint,
+                        filters=filters,
+                        offset=offset,
+                        limit=limit,
+                    )
+                    count = len(payload)
+                elif view == "full":
+                    body, total, count = pf.store.indexed_ticket_json_response(
+                        sprint=sprint,
+                        filters=filters,
+                        offset=offset,
+                        limit=limit,
+                    )
+                else:
+                    payload, total = pf.store.indexed_ticket_payloads(
+                        sprint=sprint,
+                        filters=filters,
+                        offset=offset,
+                        limit=limit,
+                    )
+                    if view == "operational":
+                        payload = [_ticket_operational_payload(ticket) for ticket in payload]
+                    count = len(payload)
             else:
                 tickets = pf.list_tickets(sprint=sprint, **filters)
                 total = len(tickets)
@@ -435,7 +458,8 @@ def _ticket_list_response(
                     else ticket.model_dump(mode="json", exclude_none=True)
                     for ticket in tickets
                 ]
-            body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+            if body is None:
+                body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
             # Do not retain a response assembled across a concurrent file change.
             if signature == _ticket_snapshot_signature(pf, sprint):
                 if len(_TICKET_LIST_RESPONSE_CACHE) >= _TICKET_LIST_RESPONSE_CACHE_LIMIT:

--- a/planfile/core/sqlite_index.py
+++ b/planfile/core/sqlite_index.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 SQLITE_INDEX_SCHEMA = "planfile.sqlite-ticket-index/v1"
 _SCHEMA_VERSION = 1
@@ -248,6 +249,92 @@ class SQLiteTicketIndex:
                 page_parameters.append(offset)
             rows = connection.execute(sql, page_parameters).fetchall()
         return [json.loads(row["summary_json"]) for row in rows], total
+
+    def list_payloads(
+        self,
+        *,
+        sprint: str,
+        filters: dict[str, Any],
+        offset: int,
+        limit: int | None,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Return full ticket payloads without materializing Pydantic models."""
+        conditions = []
+        parameters: list[Any] = []
+        if sprint != "all":
+            conditions.append("sprint=?")
+            parameters.append(sprint)
+        for key in ("status", "priority", "source"):
+            value = filters.get(key)
+            if value is None:
+                continue
+            conditions.append(f"{key}=?")
+            parameters.append(str(getattr(value, "value", value)))
+        where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+        with self._connect() as connection:
+            total = int(
+                connection.execute(
+                    f"SELECT COUNT(*) AS count FROM tickets{where}",
+                    parameters,
+                ).fetchone()["count"]
+            )
+            sql = f"SELECT ticket_json FROM tickets{where} ORDER BY position"
+            page_parameters = list(parameters)
+            if limit is not None:
+                sql += " LIMIT ? OFFSET ?"
+                page_parameters.extend((limit, offset))
+            elif offset:
+                sql += " LIMIT -1 OFFSET ?"
+                page_parameters.append(offset)
+            rows = connection.execute(sql, page_parameters).fetchall()
+        return [json.loads(row["ticket_json"]) for row in rows], total
+
+    def render_payloads(
+        self,
+        *,
+        sprint: str,
+        filters: dict[str, Any],
+        offset: int,
+        limit: int | None,
+    ) -> tuple[bytes, int, int]:
+        """Render a full JSON array directly from stored canonical ticket JSON."""
+        conditions = []
+        parameters: list[Any] = []
+        if sprint != "all":
+            conditions.append("sprint=?")
+            parameters.append(sprint)
+        for key in ("status", "priority", "source"):
+            value = filters.get(key)
+            if value is None:
+                continue
+            conditions.append(f"{key}=?")
+            parameters.append(str(getattr(value, "value", value)))
+        where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+        with self._connect() as connection:
+            total = int(
+                connection.execute(
+                    f"SELECT COUNT(*) AS count FROM tickets{where}",
+                    parameters,
+                ).fetchone()["count"]
+            )
+            sql = f"SELECT ticket_json FROM tickets{where} ORDER BY position"
+            page_parameters = list(parameters)
+            if limit is not None:
+                sql += " LIMIT ? OFFSET ?"
+                page_parameters.extend((limit, offset))
+            elif offset:
+                sql += " LIMIT -1 OFFSET ?"
+                page_parameters.append(offset)
+            cursor = connection.execute(sql, page_parameters)
+            body = bytearray(b"[")
+            count = 0
+            for row in cursor:
+                if count:
+                    body.extend(b",")
+                body.extend(row["ticket_json"].encode("utf-8"))
+                count += 1
+            body.extend(b"]")
+        return bytes(body), total, count
 
     def status(self, signature: tuple | None = None) -> dict[str, Any]:
         if not self.path.exists():

--- a/planfile/core/store.py
+++ b/planfile/core/store.py
@@ -56,6 +56,7 @@ class Store(StoreFileMixin, TicketStoreMixin):
         self._forensic_log_receipt_path = self.base_dir / "events" / ".logs.dsl.v1"
         self._evidence_dir = self.base_dir / "evidence"
         self._ticket_index_path = self.base_dir / "index" / "tickets.sqlite3"
+        self._ticket_index_rebuild_lock_path = self.base_dir / "index" / ".rebuild.lock"
         self._history_locations_path = self.base_dir / "index" / "history-locations.yaml"
 
     def _storage_config(self) -> dict:
@@ -1263,6 +1264,17 @@ class Store(StoreFileMixin, TicketStoreMixin):
         index = self._sqlite_ticket_index()
         if not (force or self.ticket_index_enabled()):
             return index.status()
+        signature = self._ticket_index_signature()
+        if not force and index.is_current(signature):
+            return index.status(signature) | {"rebuilt": False}
+        with self.ticket_index_rebuild_lock():
+            signature = self._ticket_index_signature()
+            if not force and index.is_current(signature):
+                return index.status(signature) | {"rebuilt": False}
+            return self._rebuild_ticket_index_unlocked(index, force=force)
+
+    def _rebuild_ticket_index_unlocked(self, index, *, force: bool) -> dict:
+        """Rebuild while the caller holds the cross-process index lock."""
         for _attempt in range(2):
             signature_before = self._ticket_index_signature()
             if not force and index.is_current(signature_before):
@@ -1286,6 +1298,28 @@ class Store(StoreFileMixin, TicketStoreMixin):
                 "tickets": count,
             }
         raise RuntimeError("ticket_index_sources_changed_during_rebuild")
+
+    @contextmanager
+    def ticket_index_rebuild_lock(self):
+        """Prevent concurrent readers from materializing duplicate full rebuilds."""
+        self._ticket_index_rebuild_lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_file = self._ticket_index_rebuild_lock_path.open("a+", encoding="utf-8")
+        try:
+            try:
+                import fcntl
+
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            except ImportError:
+                pass
+            yield
+        finally:
+            try:
+                import fcntl
+
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            except ImportError:
+                pass
+            lock_file.close()
 
     def configure_ticket_index(self, enabled: bool, *, before_mutation=None) -> dict:
         """Enable/disable SQLite indexing without deleting its rebuildable data."""
@@ -1322,6 +1356,40 @@ class Store(StoreFileMixin, TicketStoreMixin):
     ) -> tuple[list[dict], int]:
         self.ensure_ticket_index()
         return self._sqlite_ticket_index().list_summaries(
+            sprint=sprint,
+            filters=filters,
+            offset=offset,
+            limit=limit,
+        )
+
+    def indexed_ticket_payloads(
+        self,
+        *,
+        sprint: str,
+        filters: dict,
+        offset: int,
+        limit: int | None,
+    ) -> tuple[list[dict], int]:
+        """Read full ticket JSON directly from the disposable SQLite projection."""
+        self.ensure_ticket_index()
+        return self._sqlite_ticket_index().list_payloads(
+            sprint=sprint,
+            filters=filters,
+            offset=offset,
+            limit=limit,
+        )
+
+    def indexed_ticket_json_response(
+        self,
+        *,
+        sprint: str,
+        filters: dict,
+        offset: int,
+        limit: int | None,
+    ) -> tuple[bytes, int, int]:
+        """Render full ticket JSON from SQLite without a Python object graph."""
+        self.ensure_ticket_index()
+        return self._sqlite_ticket_index().render_payloads(
             sprint=sprint,
             filters=filters,
             offset=offset,

--- a/tests/test_sqlite_ticket_index.py
+++ b/tests/test_sqlite_ticket_index.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 
 import yaml
 from fastapi.testclient import TestClient
@@ -75,6 +78,66 @@ def test_summary_api_pages_and_filters_in_sqlite_without_full_list(tmp_path, mon
     assert [ticket["name"] for ticket in response.json()] == ["Ticket 3", "Ticket 5"]
     assert response.headers["X-Total-Count"] == "5"
     assert response.headers["X-Result-Count"] == "2"
+
+
+def test_full_and_operational_api_views_use_sqlite_without_model_cache(
+    tmp_path, monkeypatch
+):
+    pf = Planfile(str(tmp_path))
+    _disable_archive(pf)
+    ticket = pf.create_ticket(name="Indexed full payload", description="details")
+    pf.store.configure_ticket_index(True)
+    monkeypatch.setattr(server, "get_planfile", lambda: pf)
+    monkeypatch.setattr(
+        pf,
+        "list_tickets",
+        lambda **_filters: (_ for _ in ()).throw(
+            AssertionError("indexed list must not materialize ticket models")
+        ),
+    )
+    server._TICKET_LIST_RESPONSE_CACHE.clear()
+    server._TICKET_LIST_LATEST.clear()
+    client = TestClient(server.app)
+
+    full = client.get("/tickets?sprint=all&limit=5000&view=full")
+    operational = client.get("/tickets?sprint=all&limit=5000&view=operational")
+
+    assert full.status_code == 200
+    assert full.json()[0]["id"] == ticket.id
+    assert full.json()[0]["description"] == "details"
+    assert operational.status_code == 200
+    assert operational.json()[0]["id"] == ticket.id
+    assert "history" not in operational.json()[0]
+
+
+def test_concurrent_stale_index_reads_perform_one_rebuild(tmp_path, monkeypatch):
+    pf = Planfile(str(tmp_path))
+    ticket = pf.create_ticket(name="Before concurrent rebuild")
+    pf.store.configure_ticket_index(True)
+    sprint_file = pf.store._sprint_file("current")
+    data = yaml.safe_load(sprint_file.read_text(encoding="utf-8"))
+    data["sprint"]["tickets"][ticket.id]["name"] = "After concurrent rebuild"
+    sprint_file.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    mirror_path(sprint_file).unlink(missing_ok=True)
+    original_records = pf.store._ticket_index_records
+    calls = 0
+    calls_lock = threading.Lock()
+
+    def counted_records():
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+        time.sleep(0.05)
+        return original_records()
+
+    monkeypatch.setattr(pf.store, "_ticket_index_records", counted_records)
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        loaded = list(pool.map(lambda _number: pf.get_ticket(ticket.id), range(8)))
+
+    assert calls == 1
+    assert {item.name for item in loaded if item is not None} == {
+        "After concurrent rebuild"
+    }
 
 
 def test_external_yaml_edit_marks_index_stale_and_self_heals(tmp_path):


### PR DESCRIPTION
## Summary
- serialize stale SQLite index rebuilds with a cross-process lock and recheck freshness after acquisition
- serve full ticket JSON directly from indexed canonical payloads without building the historical Pydantic model cache
- serve operational projections from indexed payloads and retain ordering, filters, pagination and counts

## Production finding
After PR #24 deployment, `hr-control` full-history reads raced on a stale index: Planfile reached 3.1 GiB RSS / 88% CPU and logged SQLite `database is locked` / `locking protocol`.

## Validation
- `pytest -q`: 370 passed, 6 skipped
- focused index/API/PLOG suite: 59 passed
- Ruff changed modules and `git diff --check`: pass
- production-data copy: 3,587 tickets / 78.3 MB JSON rendered in 0.74 s, 214 MiB peak RSS, no `_ticket_model_cache`
- todo2code focused extraction: `z-ai/glm-5.2` via OpenRouter/CoreWeave, no degradation, 0 blocking diagnostics (whole-repo trend remains noisy/non-gating)

Planfile ticket: PLF-3776