### PR TITLE
fix: evict superseded ticket list responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Serialized stale SQLite index rebuilds across readers and serve full and
   operational ticket lists directly from the index, avoiding concurrent archive
   materialization, SQLite reset races, and multi-gigabyte model caches.
+- Evict superseded signature versions of the same ticket-list response so a
+  frequently changing full-history query retains one serialized body, not four.
 
 ### Added
 - Added a public, append-only `PLOG/1` forensic timeline in

--- a/planfile/api/server.py
+++ b/planfile/api/server.py
@@ -415,7 +415,7 @@ def _ticket_list_response(
                 },
             )
         signature = _ticket_snapshot_signature(pf, sprint)
-        key = (sprint, tuple(sorted(filters.items())), offset, limit, view, signature)
+        key = query_key + (signature,)
         cached = _TICKET_LIST_RESPONSE_CACHE.get(key)
         if cached is not None:
             body, total, count = cached
@@ -462,6 +462,10 @@ def _ticket_list_response(
                 body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
             # Do not retain a response assembled across a concurrent file change.
             if signature == _ticket_snapshot_signature(pf, sprint):
+                logical_query = key[:-1]
+                for existing_key in tuple(_TICKET_LIST_RESPONSE_CACHE):
+                    if existing_key[:-1] == logical_query:
+                        _TICKET_LIST_RESPONSE_CACHE.pop(existing_key, None)
                 if len(_TICKET_LIST_RESPONSE_CACHE) >= _TICKET_LIST_RESPONSE_CACHE_LIMIT:
                     _TICKET_LIST_RESPONSE_CACHE.clear()
                 _TICKET_LIST_RESPONSE_CACHE[key] = (body, total, count)

--- a/tests/test_ticket_api_events.py
+++ b/tests/test_ticket_api_events.py
@@ -1078,6 +1078,31 @@ def test_tickets_api_reuses_serialized_unchanged_snapshot(tmp_path, monkeypatch)
     assert calls == 2
 
 
+def test_ticket_list_cache_evicts_superseded_versions_of_the_same_query(
+    tmp_path, monkeypatch
+):
+    pf = Planfile(str(tmp_path))
+    ticket = pf.create_ticket(name="Cache version 0", source=TicketSource(tool="test"))
+    monkeypatch.setattr(server, "get_planfile", lambda: pf)
+    server._TICKET_LIST_RESPONSE_CACHE.clear()
+    server._TICKET_LIST_LATEST.clear()
+    client = TestClient(server.app)
+    path = "/tickets?sprint=all&limit=5000&view=full"
+
+    for version in range(6):
+        if version:
+            pf.update_ticket(ticket.id, name=f"Cache version {version}")
+        assert client.get(path).status_code == 200
+
+    project_keys = [
+        key
+        for key in server._TICKET_LIST_RESPONSE_CACHE
+        if key[0] == str(pf.store.project_dir)
+    ]
+    assert len(project_keys) == 1
+    assert client.get(path).json()[0]["name"] == "Cache version 5"
+
+
 def test_dashboard_gets_bounded_stale_snapshot_during_mutation_burst(tmp_path, monkeypatch):
     pf = Planfile(str(tmp_path))
     ticket = pf.create_ticket(name="Before burst", source=TicketSource(tool="test"))


### PR DESCRIPTION
## Summary
- include project identity in ticket-list response cache keys
- evict the older signature-specific body for the same logical query before caching the new version
- retain one 78 MB full-history body per query instead of up to four after successive ticket mutations

## Validation
- `pytest -q`: 371 passed, 6 skipped
- targeted cache/index/API suite: 54 passed
- Ruff changed modules and `git diff --check`: pass
- production observation after PR #25: indexed burst stayed below 287 MiB; follow-up addresses the remaining multi-version body retention

Planfile ticket: PLF-3777